### PR TITLE
Fix links after the transfer under pysal org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 <img src="https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/logo.png" width="50%">
 
 ## Introduction
-Momepy is a library for quantitative analysis of urban form - urban morphometrics. It is built on top of [GeoPandas](http://geopandas.org), [PySAL](http://pysal.org) and [networkX](http://networkx.github.io).
+Momepy is a library for quantitative analysis of urban form - urban morphometrics. It is
+part of [PySAL (Python Spatial Analysis Library)](http://pysal.org) and is built on top
+of [GeoPandas](http://geopandas.org), other [PySAL](http://pysal.org) modules and
+[networkX](http://networkx.github.io).
 
 > *momepy* stands for Morphological Measuring in Python
 
@@ -102,7 +105,7 @@ If you have a question regarding momepy, feel free to open an issue on GitHub. E
 
 ## Acknowledgements
 
-Initial release of momepy was a result of a research of [Urban Design Studies Unit (UDSU)](http://udsu-strath.com) supported by the Axel and Margaret Ax:son Johnson Foundation as a part of “The Urban Form Resilience Project” in partnership with University of Strathclyde in Glasgow, UK. Further development was supported by [Geographic Data Science Lab](https://www.liverpool.ac.uk/geographic-data-science/) of the University of Liverpool wihtin [Urban Grammar AI](https://urbangrammarai.github.io) research project.
+Initial release of momepy was a result of a research of [Urban Design Studies Unit (UDSU)](http://udsu-strath.com) supported by the Axel and Margaret Ax:son Johnson Foundation as a part of “The Urban Form Resilience Project” in partnership with University of Strathclyde in Glasgow, UK. Further development was supported by [Geographic Data Science Lab](https://www.liverpool.ac.uk/geographic-data-science/) of the University of Liverpool wihtin [Urban Grammar AI](https://urbangrammarai.xyz) research project.
 
 ---
 Copyright (c) 2018- Martin Fleischmann

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # momepy
-[![Documentation Status](https://readthedocs.org/projects/momepy/badge/?version=latest)](http://docs.momepy.org/en/latest/?badge=latest) [![Actions Status](https://github.com/martinfleis/momepy/workflows/Tests/badge.svg)](https://github.com/martinfleis/momepy/actions?query=workflow%3ATests)
-[![codecov](https://codecov.io/gh/martinfleis/momepy/branch/main/graph/badge.svg)](https://codecov.io/gh/martinfleis/momepy) [![CodeFactor](https://www.codefactor.io/repository/github/martinfleis/momepy/badge)](https://www.codefactor.io/repository/github/martinfleis/momepy) [![DOI](https://joss.theoj.org/papers/10.21105/joss.01807/status.svg)](https://doi.org/10.21105/joss.01807)
+[![Documentation Status](https://readthedocs.org/projects/momepy/badge/?version=latest)](http://docs.momepy.org/en/latest/?badge=latest) [![Actions Status](https://github.com/pysal/momepy/workflows/Tests/badge.svg)](https://github.com/pysal/momepy/actions?query=workflow%3ATests)
+[![codecov](https://codecov.io/gh/pysal/momepy/branch/main/graph/badge.svg?token=VNn0WR5JWT)](https://codecov.io/gh/pysal/momepy) [![CodeFactor](https://www.codefactor.io/repository/github/pysal/momepy/badge)](https://www.codefactor.io/repository/github/pysal/momepy) [![DOI](https://joss.theoj.org/papers/10.21105/joss.01807/status.svg)](https://doi.org/10.21105/joss.01807)
 
 
-<img src="https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/logo.png" width="50%">
+<img src="https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/logo.png" width="50%">
 
 ## Introduction
 Momepy is a library for quantitative analysis of urban form - urban morphometrics. It is built on top of [GeoPandas](http://geopandas.org), [PySAL](http://pysal.org) and [networkX](http://networkx.github.io).
@@ -40,7 +40,7 @@ coverage = momepy.AreaRatio(tessellation, buildings, left_areas=tessellation.are
 tessellation['CAR'] = coverage.series
 ```
 
-![Coverage Area Ratio](https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/example1.png)
+![Coverage Area Ratio](https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/example1.png)
 
 ```py
 area_simpson = momepy.Simpson(tessellation, values='area',
@@ -49,13 +49,13 @@ area_simpson = momepy.Simpson(tessellation, values='area',
 tessellation['area_simpson'] = area_simpson.series
 ```
 
-![Local Simpson's diversity of area](https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/diversity_22_0.png)
+![Local Simpson's diversity of area](https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/diversity_22_0.png)
 
 ```py
 G = momepy.straightness_centrality(G)
 ```
 
-![Straightness centrality](https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/centrality_27_0.png)
+![Straightness centrality](https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/centrality_27_0.png)
 
 
 ## How to cite

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Momepy aims to provide a wide range of tools for a systematic and exhaustive ana
 
 Comments, suggestions, feedback, and contributions, as well as bug reports, are very welcome.
 
+The package is currently maintained by @martinfleis and @jGaboardi.
+
 ## Getting Started
 Quick and easy [getting started guide](http://docs.momepy.org/en/stable/user_guide/getting_started.html) is part of the [User Guide](http://docs.momepy.org/en/stable/user_guide/intro.html).
 

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -45,7 +45,7 @@
     // defaults to 10 min
     //"install_timeout": 600,
     // the base URL to show a commit for the project.
-    "show_commit_url": "http://github.com/martinfleis/momepy/commit/",
+    "show_commit_url": "http://github.com/pysal/momepy/commit/",
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
     // "pythons": ["2.7", "3.6"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,7 @@ html_theme = "pydata_sphinx_theme"
 # documentation.
 #
 html_theme_options = {
-    "github_url": "https://github.com/martinfleis/momepy",
+    "github_url": "https://github.com/pysal/momepy",
     "twitter_url": "https://twitter.com/martinfleis",
     "google_analytics_id": "UA-6190355-13",
 }
@@ -247,9 +247,9 @@ nbsphinx_prolog = r"""
     .. note::
 
         | This page was generated from `{{ docname }}`__.
-        | Interactive online version: :raw-html:`<a href="https://mybinder.org/v2/gh/martinfleis/momepy/master?urlpath=lab/tree/docs/{{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>`
+        | Interactive online version: :raw-html:`<a href="https://mybinder.org/v2/gh/pysal/momepy/master?urlpath=lab/tree/docs/{{ docname }}"><img alt="Binder badge" src="https://mybinder.org/badge_logo.svg" style="vertical-align:text-bottom"></a>`
 
-        __ https://github.com/martinfleis/momepy/blob/master/docs/{{ docname }}
+        __ https://github.com/pysal/momepy/blob/master/docs/{{ docname }}
 """
 
 
@@ -275,4 +275,4 @@ def linkcode_resolve(domain, info):
     except Exception:
         filename = info["module"].replace(".", "/") + ".py"
     tag = "main" if "+" in release else ("v" + release)
-    return "https://github.com/martinfleis/momepy/blob/%s/%s" % (tag, filename)
+    return "https://github.com/pysal/momepy/blob/%s/%s" % (tag, filename)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -46,7 +46,7 @@ want to use command line, you can fork momepy repository using following::
 
     git clone git@github.com:your-user-name/momepy.git momepy-yourname
     cd momepy-yourname
-    git remote add upstream git://github.com/martinfleis/momepy.git
+    git remote add upstream git://github.com/pysal/momepy.git
 
 This creates the directory momepy-yourname and connects your repository to
 the upstream (main project) momepy repository.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,8 @@ Introduction
 ------------
 
 Momepy is a library for quantitative analysis of urban form - urban
-morphometrics. It is built on top of `GeoPandas`_, `PySAL`_ and
+morphometrics. It is part of `PySAL (Python Spatial Analysis Library)`_
+and is built on top of `GeoPandas`_, other `PySAL`_ modules and
 `networkX`_.
 
     *momepy* stands for Morphological Measuring in Python
@@ -166,9 +167,10 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+.. _PySAL (Python Spatial Analysis Library): http://pysal.org
 .. _GeoPandas: http://geopandas.org
 .. _PySAL: http://pysal.org
 .. _networkX: http://networkx.github.io
 .. _Urban Design Studies Unit (UDSU): http://udsu-strath.com
 .. _Geographic Data Science Lab: https://www.liverpool.ac.uk/geographic-data-science/
-.. _Urban Grammar AI: https://urbangrammarai.github.io
+.. _Urban Grammar AI: https://urbangrammarai.xyz

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,8 @@ elements, while focused on building footprints and street networks.
 Comments, suggestions, feedback, and contributions, as well as bug
 reports, are very welcome.
 
+The package is currently maintained by `@martinfleis`_ and `@jGaboardi`_.
+
 https://github.com/pysal/momepy
 
 Install
@@ -174,3 +176,5 @@ Indices and tables
 .. _Urban Design Studies Unit (UDSU): http://udsu-strath.com
 .. _Geographic Data Science Lab: https://www.liverpool.ac.uk/geographic-data-science/
 .. _Urban Grammar AI: https://urbangrammarai.xyz
+.. _@martinfleis: http://github.org/martinfleis
+.. _@jGaboardi: http://github.org/jGaboardi

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ elements, while focused on building footprints and street networks.
 Comments, suggestions, feedback, and contributions, as well as bug
 reports, are very welcome.
 
-https://github.com/martinfleis/momepy
+https://github.com/pysal/momepy
 
 Install
 -------
@@ -62,7 +62,7 @@ Examples
                                right_areas='area', unique_id='uID')
    tessellation['CAR'] = coverage.series
 
-.. figure:: https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/example1.png
+.. figure:: https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/example1.png
    :alt: Coverage Area Ratio
 
    Coverage Area Ratio
@@ -74,7 +74,7 @@ Examples
                                  unique_id='uID')
    tessellation['area_simpson'] = area_simpson.series
 
-.. figure:: https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/diversity_22_0.png
+.. figure:: https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/diversity_22_0.png
    :alt: Local Simpson's diversity of area
 
    Local Simpson's diversity of area
@@ -83,7 +83,7 @@ Examples
 
    G = momepy.straightness_centrality(G)
 
-.. figure:: https://raw.githubusercontent.com/martinfleis/momepy/main/docs/_static/centrality_27_0.png
+.. figure:: https://raw.githubusercontent.com/pysal/momepy/main/docs/_static/centrality_27_0.png
    :alt: Straightness centrality
 
    Straightness centrality

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -59,7 +59,7 @@ installing using pip only::
 Using Docker
 ------------
 
-You can also use `Dockerfile <https://github.com/martinfleis/momepy/tree/main/environments>`_
+You can also use `Dockerfile <https://github.com/pysal/momepy/tree/main/environments>`_
 to build minimal a environment for momepy, or
 get the official image from Docker Hub::
 
@@ -72,7 +72,7 @@ For example::
 Note that images are available from version 0.4.
 
 See more in the
-`ReadMe <https://github.com/martinfleis/momepy/blob/main/environments/Readme.md>`_
+`ReadMe <https://github.com/pysal/momepy/blob/main/environments/Readme.md>`_
 
 If you need the full stack of geospatial Python libraries, use `darribas/gds_env <https://darribas.org/gds_env/>`_
 which provides the updated platform for Geographic Data Science (including momepy)::
@@ -84,16 +84,16 @@ Install from the repository
 ---------------------------
 
 If you want to work with the latest development version of momepy, you can do so
-by cloning `GitHub repository <https://github.com/martinfleis/momepy>`__ and
+by cloning `GitHub repository <https://github.com/pysal/momepy>`__ and
 installing momepy from local directory::
 
-    git clone https://github.com/martinfleis/momepy.git
+    git clone https://github.com/pysal/momepy.git
     cd momepy
     pip install .
 
 Alternatively, you can install the latest version directly from GitHub::
 
-    pip install git+git://github.com/martinfleis/momepy.git
+    pip install git+git://github.com/pysal/momepy.git
 
 Installing directly from repository might face the same dependency issues as
 described above regarding installing using pip. To ensure that environment is

--- a/environments/Readme.md
+++ b/environments/Readme.md
@@ -1,6 +1,10 @@
 # momepy container
 
-`momepy` is a library for quantitative analysis of urban form - urban morphometrics - built on top of GeoPandas, PySAL and networkX. This container provides the minimal environment needed to run momepy.
+Momepy is a library for quantitative analysis of urban form - urban morphometrics. It is
+part of [PySAL (Python Spatial Analysis Library)](http://pysal.org) and is built on top
+of [GeoPandas](http://geopandas.org), other [PySAL](http://pysal.org) modules and
+[networkX](http://networkx.github.io).
+This container provides the minimal environment needed to run momepy.
 
 Documentation: http://docs.momepy.org/en/stable/
 

--- a/environments/Readme.md
+++ b/environments/Readme.md
@@ -1,10 +1,10 @@
 # momepy container
 
-`momepy` is a library for quantitative analysis of urban form - urban morphometrics - built on top of GeoPandas, PySAL and networkX. This container provides the minimal environment needed to run momepy. 
+`momepy` is a library for quantitative analysis of urban form - urban morphometrics - built on top of GeoPandas, PySAL and networkX. This container provides the minimal environment needed to run momepy.
 
 Documentation: http://docs.momepy.org/en/stable/
 
-Source code: https://github.com/martinfleis/momepy
+Source code: https://github.com/pysal/momepy
 
 Docker repository: https://hub.docker.com/repository/docker/martinfleis/momepy
 


### PR DESCRIPTION
Fixing links from `martinfleis` -> `pysal` and trying to figure out which bits of CI work and which do not.

Closes #301