### PR TITLE
REF: simplify calculation of Simpson diversity

### DIFF
--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -367,7 +367,7 @@ def simpson_diversity(values, bins=None, categorical=False):
 
     Parameters
     ----------
-    values : array-like
+    values : pandas.Series
         list of values
     bins : array, optional
         array of top edges of classification bins. Result of binnng.bins.
@@ -396,9 +396,9 @@ def simpson_diversity(values, bins=None, categorical=False):
         sample_bins = mc.UserDefined(values, bins)
         counts = sample_bins.counts
 
-    freqs = counts / counts.sum()
+    N = sum(counts)
 
-    return (freqs * freqs).sum()
+    return sum((n / N) ** 2 for n in counts if n != 0)
 
 
 class Gini:

--- a/momepy/diversity.py
+++ b/momepy/diversity.py
@@ -327,7 +327,7 @@ class Simpson:
         if not categorical:
             self.bins = classify(data, scheme=binning, **classification_kwds).bins
         else:
-            self.bins = categories
+            self.bins = None
 
         results_list = []
         for index in tqdm(data.index, total=data.shape[0], disable=not verbose):
@@ -363,14 +363,14 @@ def simpson_diversity(values, bins=None, categorical=False):
 
         \\lambda=\\sum_{i=1}^{R} p_{i}^{2}
 
-    Formula adapted from ``scikit-bio``.
 
     Parameters
     ----------
     values : pandas.Series
         list of values
     bins : array, optional
-        array of top edges of classification bins. Result of binnng.bins.
+        array of top edges of classification bins.
+        Should be equalt to the result of binnng.bins.
     categorical : bool (default False)
         treat values as categories (will not use ``bins``)
 

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -99,7 +99,6 @@ class TestDiversity:
             self.sw,
             "uID",
             categorical=True,
-            categories=range(15),
         ).series
         assert cat2[0] == pytest.approx(0.15)
 


### PR DESCRIPTION
I realised that the `simpson_diversity` helper function can be much simpler than it was. Also, `categories` keyword made no difference to the calculation so I dropped it from the helper. It is still part of the signature of `Simpson` though, to avoid any breakage. I assume that it will get cleaned with the API revamp (#308).