### PR TITLE
MAINT: replace LooseVersion with packaging.version

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,7 @@ jobs:
       run:
         shell: bash -l {0}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         env:

--- a/ci/envs/310-dev.yaml
+++ b/ci/envs/310-dev.yaml
@@ -15,6 +15,7 @@ dependencies:
   - inequality
   - pygeos
   - dask
+  - packaging
   # for mapclassify
   - scikit-learn
   - pip:

--- a/ci/envs/310-latest.yaml
+++ b/ci/envs/310-latest.yaml
@@ -14,3 +14,4 @@ dependencies:
   - osmnx
   - pygeos
   - inequality
+  - packaging

--- a/ci/envs/37-minimal.yaml
+++ b/ci/envs/37-minimal.yaml
@@ -14,3 +14,4 @@ dependencies:
   - osmnx
   - pygeos
   - inequality
+  - packaging

--- a/ci/envs/38-latest.yaml
+++ b/ci/envs/38-latest.yaml
@@ -14,3 +14,4 @@ dependencies:
   - osmnx
   - pygeos
   - inequality
+  - packaging

--- a/ci/envs/39-latest.yaml
+++ b/ci/envs/39-latest.yaml
@@ -8,6 +8,7 @@ dependencies:
   - networkx
   - tqdm
   - mapclassify
+  - packaging
   # testing
   - pytest
   - pytest-cov

--- a/momepy/__init__.py
+++ b/momepy/__init__.py
@@ -1,16 +1,16 @@
 import momepy.datasets
 
+from .coins import *
 from .dimension import *
 from .distribution import *
 from .diversity import *
 from .elements import *
 from .graph import *
 from .intensity import *
+from .preprocessing import *
 from .shape import *
 from .utils import *
 from .weights import *
-from .preprocessing import *
-from .coins import *
 
 __author__ = "Martin Fleischmann"
 __author_email__ = "martin@martinfleischmann.net"

--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -9,13 +9,14 @@ Adapted for momepy by: Andres Morfin, Niki Patrinopoulou, and Ioannis Daramouska
 Date: May 29, 2021
 """
 
-import math
-import numpy as np
-from shapely.geometry import LineString, MultiLineString
-from shapely import ops
-import geopandas as gpd
-import pandas as pd
 import collections
+import math
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely import ops
+from shapely.geometry import LineString, MultiLineString
 
 
 class COINS:

--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -14,7 +14,6 @@ from tqdm.auto import tqdm
 
 from .shape import _circle_radius
 
-
 __all__ = [
     "Area",
     "Perimeter",

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -3,14 +3,15 @@
 
 # elements.py
 # generating derived elements (street edge, block)
-from distutils.version import LooseVersion
+import warnings
 
 import geopandas as gpd
 import libpysal
-import warnings
 import numpy as np
-import pygeos
 import pandas as pd
+import pygeos
+
+from packaging.version import Version
 from scipy.spatial import Voronoi
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import polygonize
@@ -26,7 +27,7 @@ __all__ = [
     "get_network_ratio",
 ]
 
-GPD_10 = str(gpd.__version__) >= LooseVersion("0.10")
+GPD_10 = Version(gpd.__version__) >= Version("0.10")
 
 
 def buffered_limit(gdf, buffer=100):

--- a/momepy/preprocessing.py
+++ b/momepy/preprocessing.py
@@ -4,7 +4,6 @@
 import collections
 import math
 import operator
-from distutils.version import LooseVersion
 import warnings
 
 import geopandas as gpd
@@ -13,6 +12,7 @@ import numpy as np
 import pandas as pd
 import pygeos
 import shapely
+from packaging.version import Version
 from tqdm.auto import tqdm
 
 from .shape import CircularCompactness
@@ -25,7 +25,7 @@ __all__ = [
     "extend_lines",
 ]
 
-GPD_10 = str(gpd.__version__) >= LooseVersion("0.10")
+GPD_10 = Version(gpd.__version__) >= Version("0.10")
 
 
 def preprocess(

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -7,9 +7,7 @@ import geopandas as gpd
 import libpysal
 import networkx as nx
 import numpy as np
-
 from shapely.geometry import Point
-
 
 __all__ = [
     "unique_id",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ networkx>=2.3
 libpysal>=4.1.0
 tqdm>=4.25
 pygeos
+packaging

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "libpysal>=4.2.0",
         "tqdm>=4.27.0",
         "pygeos",
+        "packaging",
     ],
     cmdclass=versioneer.get_cmdclass(),
 )

--- a/tests/test_coins.py
+++ b/tests/test_coins.py
@@ -1,9 +1,9 @@
 import geopandas as gpd
-import momepy as mm
 import pandas as pd
-
-from pandas.testing import assert_index_equal, assert_series_equal
 import pytest
+from pandas.testing import assert_index_equal, assert_series_equal
+
+import momepy as mm
 
 
 class TestCOINS:

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -1,12 +1,13 @@
 import geopandas as gpd
-import momepy as mm
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+from pytest import approx
+from shapely.geometry import LineString, Point, Polygon
+
+import momepy as mm
 from momepy import sw_high
 from momepy.shape import _make_circle
-from pytest import approx
-from shapely.geometry import Polygon, LineString, Point
 
 
 class TestDimensions:

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,8 +1,9 @@
 import geopandas as gpd
-import momepy as mm
 import numpy as np
 import pytest
 from libpysal.weights import Queen
+
+import momepy as mm
 
 
 class TestDistribution:

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -1,9 +1,10 @@
 import geopandas as gpd
-import momepy as mm
 import numpy as np
 import pytest
-from momepy import sw_high
 from pytest import approx
+
+import momepy as mm
+from momepy import sw_high
 
 
 class TestDiversity:

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,15 +1,14 @@
-import geopandas as gpd
-import momepy as mm
-import numpy as np
 from random import shuffle
 
+import geopandas as gpd
+import numpy as np
 import pytest
-
-from shapely.geometry import Polygon, MultiPoint, LineString
-from shapely import affinity
-
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_index_equal
+from shapely import affinity
+from shapely.geometry import LineString, MultiPoint, Polygon
+
+import momepy as mm
 
 
 class TestElements:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,11 +1,11 @@
-from distutils.version import LooseVersion
-
 import geopandas as gpd
-import momepy as mm
 import networkx as nx
 import pytest
+from packaging.version import Version
 
-NX_26 = str(nx.__version__) < LooseVersion("2.6")
+import momepy as mm
+
+NX_26 = Version(nx.__version__) < Version("2.6")
 
 
 class TestGraph:

--- a/tests/test_intensity.py
+++ b/tests/test_intensity.py
@@ -1,9 +1,10 @@
 import geopandas as gpd
-import momepy as mm
 import numpy as np
 import pytest
 from libpysal.weights import Queen
 from pytest import approx
+
+import momepy as mm
 
 
 class TestIntensity:

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,14 +1,13 @@
-from distutils.version import LooseVersion
-
 import geopandas as gpd
-import momepy as mm
 import numpy as np
 import pytest
-
-from shapely.geometry import Polygon, MultiPoint, LineString
+from packaging.version import Version
 from shapely import affinity
+from shapely.geometry import LineString, MultiPoint, Polygon
 
-GPD_10 = str(gpd.__version__) >= LooseVersion("0.10")
+import momepy as mm
+
+GPD_10 = Version(gpd.__version__) >= Version("0.10")
 
 
 class TestPreprocessing:

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -1,11 +1,11 @@
 import math
 
 import geopandas as gpd
-import momepy as mm
 import numpy as np
 from pytest import approx
-from shapely.geometry import Point, Polygon, MultiLineString
+from shapely.geometry import MultiLineString, Point, Polygon
 
+import momepy as mm
 from momepy.shape import _circle_area
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
 import geopandas as gpd
-import momepy as mm
 import networkx
 import numpy as np
-import pytest
 import osmnx as ox
-
+import pytest
 from shapely.geometry import LineString
+
+import momepy as mm
 
 
 class TestUtils:

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,7 +1,8 @@
 import geopandas as gpd
 import libpysal
-import momepy as mm
 import pytest
+
+import momepy as mm
 
 
 class TestWeights:


### PR DESCRIPTION
`LooseVersion` is deprecated. The warning recommends replacing it with `packaging.version`, which is exactly what I am doing here. Apart from that, I have also ran `isort` and temporarily turned off `fail-fast` in CI, while there's that GeoPandas regression. 