### PR TITLE
TST: skip to avoid geopandas regression

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -7,8 +7,12 @@ from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_index_equal
 from shapely import affinity
 from shapely.geometry import LineString, MultiPoint, Polygon
+from packaging.version import Version
 
 import momepy as mm
+
+# https://github.com/geopandas/geopandas/issues/2282
+GPD_REGR = Version("0.10.2") < Version(gpd.__version__) < Version("0.11")
 
 
 class TestElements:
@@ -120,6 +124,7 @@ class TestElements:
         buildings_id = mm.get_network_id(self.df_buildings, self.df_streets, "nID")
         assert not buildings_id.isna().any()
 
+    @pytest.mark.skipif(GPD_REGR, reason="regression in geopandas")
     def test_get_node_id(self):
         nx = mm.gdf_to_nx(self.df_streets)
         nodes, edges = mm.nx_to_gdf(nx)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,12 @@ import numpy as np
 import osmnx as ox
 import pytest
 from shapely.geometry import LineString
+from packaging.version import Version
 
 import momepy as mm
+
+# https://github.com/geopandas/geopandas/issues/2282
+GPD_REGR = Version("0.10.2") < Version(gpd.__version__) < Version("0.11")
 
 
 class TestUtils:
@@ -96,6 +100,7 @@ class TestUtils:
         with pytest.raises(ValueError):
             mm.gdf_to_nx(self.df_streets, approach="dual", directed=True)
 
+    @pytest.mark.skipif(GPD_REGR, reason="regression in geopandas")
     def test_nx_to_gdf(self):
         nx = mm.gdf_to_nx(self.df_streets)
         nodes, edges, W = mm.nx_to_gdf(nx, spatial_weights=True)


### PR DESCRIPTION
We have two tests failiung due to https://github.com/geopandas/geopandas/issues/2282 . Skipping to avoid CI failures. It will be fixed in geopandas ahead of 0.11.