### PR TITLE
RLS: 0.5.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ Changelog
 Version 0.5.3 (April 9, 2022)
 -----------------------------
 
-Minor patch release fixing the issue with a generation blocks.
+Minor patch release primarily fixing an issue with momepy.Blocks and a creation of angular graphs.
 
+Fixes:
+
+- BUG: Fix angle computation in graph creation with dual approach (#347)
 - BUG: fix issue with blocks within another blocks (#351)
 
 


### PR DESCRIPTION
I mistakenly committed first commit of a changelog directly to main. This adds the other bug fix. I want to release today to resolve https://github.com/martinfleis/numerical-taxonomy-paper/issues/2 that has been coming up for some time but until yesterday I wasn't able to reproduce it. It should also mostly resolve https://github.com/pysal/momepy/discussions/339