### PR TITLE
ENH: support bi-directional roads in gdf_to_nx

### DIFF
--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -65,7 +65,6 @@ def _generate_primal(G, gdf_network, fields, multigraph, oneway_column=None):
             key += 1
 
             if oneway_column:
-                print(row)
                 oneway = bool(getattr(row, oneway_column))
                 if not oneway:
                     G.add_edge(last, first, key=key, **attributes)
@@ -241,7 +240,9 @@ def gdf_to_nx(
 
     if approach == "primal":
         if oneway_column and ((not directed) and (not multigraph)):
-            raise ValueError("Bidirectional lines are only supported for directed multigraphs.")
+            raise ValueError(
+                "Bidirectional lines are only supported for directed multigraphs."
+            )
 
         _generate_primal(net, gdf_network, fields, multigraph, oneway_column)
 

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -47,7 +47,7 @@ def _angle(a, b, c):
     return abs((a2 - a1 + 180) % 360 - 180)
 
 
-def _generate_primal(G, gdf_network, fields, multigraph):
+def _generate_primal(G, gdf_network, fields, multigraph, oneway_column=None):
     """
     Generate primal graph.
     Helper for gdf_to_nx.
@@ -63,6 +63,13 @@ def _generate_primal(G, gdf_network, fields, multigraph):
         if multigraph:
             G.add_edge(first, last, key=key, **attributes)
             key += 1
+
+            if oneway_column:
+                print(row)
+                oneway = bool(getattr(row, oneway_column))
+                if not oneway:
+                    G.add_edge(last, first, key=key, **attributes)
+                    key += 1
         else:
             G.add_edge(first, last, **attributes)
 
@@ -126,6 +133,7 @@ def gdf_to_nx(
     directed=False,
     angles=True,
     angle="angle",
+    oneway_column=None,
 ):
     """
     Convert LineString GeoDataFrame to networkx.MultiGraph or other Graph as per
@@ -160,6 +168,9 @@ def gdf_to_nx(
     angle : str, default 'angle'
         name of attribute of angle between LineStrings which will be saved to graph.
         Ignored if ``approach="primal"``.
+    oneway_column : str, default None
+        create an additional edge for each LineString which allows bidirectional path traversal by
+        specifying the boolean column in the GeoDataFrame.
 
     Returns
     -------
@@ -229,7 +240,10 @@ def gdf_to_nx(
     fields = list(gdf_network.columns)
 
     if approach == "primal":
-        _generate_primal(net, gdf_network, fields, multigraph)
+        if oneway_column and ((not directed) and (not multigraph)):
+            raise ValueError("Bidirectional lines are only supported for directed multigraphs.")
+
+        _generate_primal(net, gdf_network, fields, multigraph, oneway_column)
 
     elif approach == "dual":
         if directed:

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -169,7 +169,9 @@ def gdf_to_nx(
         Ignored if ``approach="primal"``.
     oneway_column : str, default None
         create an additional edge for each LineString which allows bidirectional path traversal by
-        specifying the boolean column in the GeoDataFrame.
+        specifying the boolean column in the GeoDataFrame. Note, that the reverse conversion
+        ``nx_to_gdf(gdf_to_nx(gdf, directed=True, oneway_column="oneway"))`` will contain
+        additional duplicated geometries.
 
     Returns
     -------
@@ -239,9 +241,9 @@ def gdf_to_nx(
     fields = list(gdf_network.columns)
 
     if approach == "primal":
-        if oneway_column and ((not directed) and (not multigraph)):
+        if oneway_column and not directed:
             raise ValueError(
-                "Bidirectional lines are only supported for directed multigraphs."
+                "Bidirectional lines are only supported for directed graphs."
             )
 
         _generate_primal(net, gdf_network, fields, multigraph, oneway_column)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,9 +99,6 @@ class TestUtils:
         with pytest.raises(ValueError):
             mm.gdf_to_nx(self.df_streets, approach="dual", directed=True)
 
-        
-        
-
     @pytest.mark.skipif(GPD_REGR, reason="regression in geopandas")
     def test_nx_to_gdf(self):
         nx = mm.gdf_to_nx(self.df_streets)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,6 +55,11 @@ class TestUtils:
         assert nx.number_of_nodes() == 29
         assert nx.number_of_edges() == 35
 
+        self.df_streets["oneway"] = True
+        self.df_streets.loc[0, "oneway"] = False  # first road section is bidirectional
+        nx = mm.gdf_to_nx(self.df_streets, directed=True, oneway_column="oneway")
+        assert nx.number_of_edges() == 36
+
         dual = mm.gdf_to_nx(self.df_streets, approach="dual", angles=False)
         assert (
             dual.edges[
@@ -93,6 +98,9 @@ class TestUtils:
 
         with pytest.raises(ValueError):
             mm.gdf_to_nx(self.df_streets, approach="dual", directed=True)
+
+        
+        
 
     @pytest.mark.skipif(GPD_REGR, reason="regression in geopandas")
     def test_nx_to_gdf(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,6 +60,9 @@ class TestUtils:
         nx = mm.gdf_to_nx(self.df_streets, directed=True, oneway_column="oneway")
         assert nx.number_of_edges() == 36
 
+        with pytest.raises(ValueError):
+            mm.gdf_to_nx(self.df_streets, directed=False, oneway_column="oneway")
+
         dual = mm.gdf_to_nx(self.df_streets, approach="dual", angles=False)
         assert (
             dual.edges[

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -60,7 +60,7 @@ class TestUtils:
         nx = mm.gdf_to_nx(self.df_streets, directed=True, oneway_column="oneway")
         assert nx.number_of_edges() == 36
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Bidirectional lines"):
             mm.gdf_to_nx(self.df_streets, directed=False, oneway_column="oneway")
 
         dual = mm.gdf_to_nx(self.df_streets, approach="dual", angles=False)


### PR DESCRIPTION
Some road sections can be passed in a bidirectional manner. Either the user has to preprocess his GeoDataFrame (to add an additional LineString in a opposite direction) or we can introduce a function where based on a boolean column, a user can specify which linestrings (roads) are `oneway` or not:

![image](https://user-images.githubusercontent.com/12762439/169399309-559ec67f-ee18-4780-8ff7-988ed3d18d1e.png)

This functionality is helpful for path finding applications in directed graphs, where the same road can be traversed in the opposite direction.