### PR TITLE
DOC: remove dev mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ If you decide to contribute to the codebase, ensure that you are using an up-to-
 Details are available in the [documentation](https://docs.momepy.org/).
 
 ## Get in touch
-If you have a question regarding momepy, feel free to open an issue on GitHub. Eventually, you can contact us on [dev@momepy.org](mailto:dev@momepy.org).
+
+If you have a question regarding momepy, feel free to open an [issue](https://github.com/pysal/momepy/issues/new/choose) or a new [discussion](https://github.com/pysal/momepy/discussions) on GitHub.
 
 ## Acknowledgements
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,8 +136,8 @@ Details are available in the :doc:`contributing guide <contributing>`.
 
 Get in touch
 ------------
-If you have a question regarding momepy, feel free to open an issue on GitHub.
-Eventually, you can contact us on dev@momepy.org.
+If you have a question regarding momepy, feel free to open an
+`issue`_ or a new `discussion`_ on GitHub.
 
 Acknowledgements
 ----------------
@@ -179,3 +179,5 @@ Indices and tables
 .. _Urban Grammar AI: https://urbangrammarai.xyz
 .. _@martinfleis: http://github.org/martinfleis
 .. _@jGaboardi: http://github.org/jGaboardi
+.. _issue: https://github.com/pysal/momepy/issues/new/choose
+.. _discussion: https://github.com/pysal/momepy/discussions


### PR DESCRIPTION
I suggest removing an option to contact us via dev@momepy.org email. It currently goes only to my email, is rarely used and practically everything that goes there should be either an issue or a discussion here. There's no need to keep any of it in a private email conversation.