### PR TITLE
BUG: return itself when no change possible in remove_false_nodes

### DIFF
--- a/momepy/preprocessing.py
+++ b/momepy/preprocessing.py
@@ -190,6 +190,8 @@ def remove_false_nodes(gdf):
     """
     Clean topology of existing LineString geometry by removal of nodes of degree 2.
 
+    Returns the original gdf if there's no node of degree 2.
+
     Parameters
     ----------
     gdf : GeoDataFrame, GeoSeries, array of pygeos geometries
@@ -275,6 +277,9 @@ def remove_false_nodes(gdf):
                 ignore_index=True,
             )
         return df.append(final, ignore_index=True)
+
+    # if there's nothing to fix, return the original dataframe
+    return gdf
 
 
 class CheckTessellationInput:

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -4,6 +4,7 @@ import pytest
 from packaging.version import Version
 from shapely import affinity
 from shapely.geometry import LineString, MultiPoint, Polygon
+from geopandas.testing import assert_geodataframe_equal
 
 import momepy as mm
 
@@ -46,6 +47,10 @@ class TestPreprocessing:
         assert len(fixed_multiindex) == 56
         assert isinstance(fixed, gpd.GeoDataFrame)
         assert sorted(self.false_network.columns) == sorted(fixed.columns)
+
+        # no node of a degree 2
+        df = self.df_streets.drop([4, 7, 17, 22])
+        assert_geodataframe_equal(df, mm.remove_false_nodes(df))
 
     def test_CheckTessellationInput(self):
         df = self.df_buildings


### PR DESCRIPTION
When there is nothing to fix, `remove_false_nodes` just does nothing but it should rather return the original df.