### PR TITLE
BUG: make coins independent of gdf index

### DIFF
--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -66,7 +66,7 @@ class COINS:
         self.already_merged = False
 
         # get indices of original gdf
-        self.uv_index = self.edge_gdf.index.tolist()
+        self.uv_index = range(len(self.edge_gdf.index))
 
         # get line segments from edge gdf
         self.lines = [list(value[1].coords) for value in edge_gdf.geometry.iteritems()]


### PR DESCRIPTION
Fix bug initially reported by @gregmaya [here](https://github.com/pysal/momepy/discussions/361#discussioncomment-3365328). 

The issue is that ```coins``` depends on ```gdfs``` with a unique index. However, this will not always be guaranteed. With the modification,  a unique index is created by ```coins``` that is used to build back ```coins.stroke_attribute()```

There were some failing tests on my end but unrelated to ```coins```.

-Andres