### PR TITLE
Added warning for gdp_to_nx if geometries are not LineStrings

### DIFF
--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -59,8 +59,9 @@ def _generate_primal(G, gdf_network, fields, multigraph, oneway_column=None):
     for row in gdf_network.itertuples():
 
         if (not (isinstance(row.geometry, LineString))):
-            warnings.warn(message="Geometry is not of type LineString",
-                          category=RuntimeWarning)
+            warnings.warn(
+                message="Geometry is not of type LineString", category=RuntimeWarning
+            )
 
         first = row.geometry.coords[0]
         last = row.geometry.coords[-1]

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -8,8 +8,7 @@ import geopandas as gpd
 import libpysal
 import networkx as nx
 import numpy as np
-from shapely.geometry import Point
-from shapely.geometry import LineString
+from shapely.geometry import Point, LineString
 
 __all__ = [
     "unique_id",

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 
 import math
+import warnings
 
 import geopandas as gpd
 import libpysal
 import networkx as nx
 import numpy as np
 from shapely.geometry import Point
+from shapely.geometry import LineString
 
 __all__ = [
     "unique_id",
@@ -55,6 +57,11 @@ def _generate_primal(G, gdf_network, fields, multigraph, oneway_column=None):
     G.graph["approach"] = "primal"
     key = 0
     for row in gdf_network.itertuples():
+
+        if (not (isinstance(row.geometry, LineString))):
+            warnings.warn(message="Geometry is not of type LineString",
+                          category=RuntimeWarning)
+
         first = row.geometry.coords[0]
         last = row.geometry.coords[-1]
 

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -55,13 +55,21 @@ def _generate_primal(G, gdf_network, fields, multigraph, oneway_column=None):
     Helper for gdf_to_nx.
     """
     G.graph["approach"] = "primal"
+
+    if not "LineString" in gdf_network.geom_type.unique():
+        warnings.warn(
+            message="The given network does not contain any LineString. This can lead to unexpected behaviour. The intended usage of the conversion function is with networks made of LineStrings only.",
+            category=RuntimeWarning,
+        )
+
+    if len(gdf_network.geom_type.unique()) > 1:
+        warnings.warn(
+            message="The given network consists of multiple geometry types. This can lead to unexpected behaviour. The intended usage of the conversion function is with networks made of LineStrings only.",
+            category=RuntimeWarning,
+        )
+
     key = 0
     for row in gdf_network.itertuples():
-
-        if (not (isinstance(row.geometry, LineString))):
-            warnings.warn(
-                message="Geometry is not of type LineString", category=RuntimeWarning
-            )
 
         first = row.geometry.coords[0]
         last = row.geometry.coords[-1]

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -56,15 +56,17 @@ def _generate_primal(G, gdf_network, fields, multigraph, oneway_column=None):
     """
     G.graph["approach"] = "primal"
 
+    msg = "%s. This can lead to unexpected behaviour. The intended usage of the conversion function is with networks made of LineStrings only."
+
     if not "LineString" in gdf_network.geom_type.unique():
         warnings.warn(
-            message="The given network does not contain any LineString. This can lead to unexpected behaviour. The intended usage of the conversion function is with networks made of LineStrings only.",
+            message=msg % "The given network does not contain any LineString.",
             category=RuntimeWarning,
         )
 
     if len(gdf_network.geom_type.unique()) > 1:
         warnings.warn(
-            message="The given network consists of multiple geometry types. This can lead to unexpected behaviour. The intended usage of the conversion function is with networks made of LineStrings only.",
+            message=msg % "The given network consists of multiple geometry types.",
             category=RuntimeWarning,
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,10 @@ import geopandas as gpd
 import networkx
 import numpy as np
 import osmnx as ox
+import warnings
 import pytest
 from shapely.geometry import LineString
+from shapely.geometry import Point
 from packaging.version import Version
 
 import momepy as mm
@@ -20,12 +22,18 @@ class TestUtils:
         self.df_tessellation = gpd.read_file(test_file_path, layer="tessellation")
         self.df_streets = gpd.read_file(test_file_path, layer="streets")
         self.df_buildings["height"] = np.linspace(10.0, 30.0, 144)
+        self.df_points = gpd.GeoDataFrame(
+            data=None, geometry=[Point(0, 0), Point(1, 1)])
 
     def test_dataset_missing(self):
         with pytest.raises(ValueError):
             mm.datasets.get_path("sffgkt")
 
     def test_gdf_to_nx(self):
+
+        with pytest.warns(RuntimeWarning):
+            nx = mm.gdf_to_nx(self.df_points)
+
         nx = mm.gdf_to_nx(self.df_streets)
         assert nx.number_of_nodes() == 29
         assert nx.number_of_edges() == 35

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,7 @@ import numpy as np
 import osmnx as ox
 import warnings
 import pytest
-from shapely.geometry import LineString
-from shapely.geometry import Point
+from shapely.geometry import LineString, Point
 from packaging.version import Version
 
 import momepy as mm

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,11 +37,11 @@ class TestUtils:
     def test_gdf_to_nx(self):
 
         # nx = mm.gdf_to_nx(self.df_points)
-        with pytest.warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning, match="The given network does not contain any LineString."):
             nx = mm.gdf_to_nx(self.df_points)
 
         # nx = mm.gdf_to_nx(self.df_points_and_linestring)
-        with pytest.warns(RuntimeWarning):
+        with pytest.warns(RuntimeWarning, match="The given network consists of multiple geometry types."):
             nx = mm.gdf_to_nx(self.df_points_and_linestring)
 
         nx = mm.gdf_to_nx(self.df_streets)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,8 @@ class TestUtils:
         self.df_streets = gpd.read_file(test_file_path, layer="streets")
         self.df_buildings["height"] = np.linspace(10.0, 30.0, 144)
         self.df_points = gpd.GeoDataFrame(
-            data=None, geometry=[Point(0, 0), Point(1, 1)])
+            data=None, geometry=[Point(0, 0), Point(1, 1)]
+        )
 
     def test_dataset_missing(self):
         with pytest.raises(ValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,10 @@ class TestUtils:
         self.df_points = gpd.GeoDataFrame(
             data=None, geometry=[Point(0, 0), Point(1, 1)]
         )
+        self.df_points_and_linestring = gpd.GeoDataFrame(
+            data=None,
+            geometry=[Point(0, 0), Point(1, 1), LineString([(1, 0), (0, 0), (1, 1)])],
+        )
 
     def test_dataset_missing(self):
         with pytest.raises(ValueError):
@@ -32,8 +36,13 @@ class TestUtils:
 
     def test_gdf_to_nx(self):
 
+        # nx = mm.gdf_to_nx(self.df_points)
         with pytest.warns(RuntimeWarning):
             nx = mm.gdf_to_nx(self.df_points)
+
+        # nx = mm.gdf_to_nx(self.df_points_and_linestring)
+        with pytest.warns(RuntimeWarning):
+            nx = mm.gdf_to_nx(self.df_points_and_linestring)
 
         nx = mm.gdf_to_nx(self.df_streets)
         assert nx.number_of_nodes() == 29

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,11 +37,16 @@ class TestUtils:
     def test_gdf_to_nx(self):
 
         # nx = mm.gdf_to_nx(self.df_points)
-        with pytest.warns(RuntimeWarning, match="The given network does not contain any LineString."):
+        with pytest.warns(
+            RuntimeWarning, match="The given network does not contain any LineString."
+        ):
             nx = mm.gdf_to_nx(self.df_points)
 
         # nx = mm.gdf_to_nx(self.df_points_and_linestring)
-        with pytest.warns(RuntimeWarning, match="The given network consists of multiple geometry types."):
+        with pytest.warns(
+            RuntimeWarning,
+            match="The given network consists of multiple geometry types.",
+        ):
             nx = mm.gdf_to_nx(self.df_points_and_linestring)
 
         nx = mm.gdf_to_nx(self.df_streets)


### PR DESCRIPTION
First of all: Thanks for momepy, a great tool for spatial analysis and processing. 

The gdp_to_nx function is pretty nice to convert data, previous read from a shape file into a geopanda frame, to a network graph. 
But from my point of view it makes only sense if the given data consist of LineStrings only, because a point will be converted to an edge with the same start and endpoint. The endpoints will not inherit any attributes from the original data.

I added a warning to inform the user about the pitfall, if any datum has a geometry != Linestring

-- Changes:
Added check and warning in function
Added minimal test if warning is thrown

kind regards