### PR TITLE
DOC: temporarily pin theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
 sphinxcontrib.bibtex
 numpydoc
-pydata_sphinx_theme
+pydata_sphinx_theme<0.10
 nbsphinx
 ipython
 myst-parser


### PR DESCRIPTION
This should fix the docs build. The issue is caused by https://github.com/pydata/pydata-sphinx-theme/pull/911 and have already been fixed in upstream in https://github.com/pydata/pydata-sphinx-theme/pull/915, so temporarily pinning until the next release is out.