### PR TITLE
bump copyright year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ autodoc_mock_imports = [
 # -- Project information -----------------------------------------------------
 
 project = "momepy"
-copyright = "2018-2021, Martin Fleischmann and PySAL Developers"
+copyright = "2018-2022, Martin Fleischmann and PySAL Developers"
 author = "Martin Fleischmann"
 
 # The short X.Y version


### PR DESCRIPTION
This PR bumps the copyright year in `conf.py` to 2022.