### PR TITLE
retry building PDF from `readthedocs.yml`

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,5 @@
 version: 2
-formats: []
+formats: [pdf]
 
 sphinx:
   configuration: docs/conf.py
@@ -10,6 +10,3 @@ python:
       - requirements: docs/requirements.txt
       - method: pip
         path: .
-
-formats:
-  - pdf

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -11,5 +11,5 @@ python:
       - method: pip
         path: .
 
- formats:
-   - pdf
+formats:
+  - pdf

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,3 +10,6 @@ python:
       - requirements: docs/requirements.txt
       - method: pip
         path: .
+
+ formats:
+   - pdf


### PR DESCRIPTION
This PR reverts 3dd803b. We may also want to try update the Python version with `readthedocs.yml`.

xref #294 