### PR TITLE
remove redundant `requirements.txt`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Test momepy
         run: |
-          pytest -v --color yes --cov-config .coveragerc --cov momepy --cov-append --cov-report term-missing --cov-report xml .
+          pytest -v --color yes --cov momepy --cov-append --cov-report term-missing --cov-report xml .
 
       - name: Test user guide
         if: contains(matrix.environment-file, '310-latest.yaml') && contains(matrix.os, 'ubuntu')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-geopandas>=0.8.0
-libpysal>=4.6.0
-networkx>=2.3
-packaging
-pandas!=1.5.0
-pygeos
-shapely>=1.8.0
-tqdm>=4.25


### PR DESCRIPTION
This PR follows up with #467
* removes `--cov-config .coveragerc` from `tests.yml` (there's no longer a `.coveragerc` file`)
* removes the redundant `requirements.txt`, which now reside within [`pyproject.toml`](https://github.com/pysal/momepy/blob/b4a415677fe3b2c0f9ce5f9700833cb88fae583f/pyproject.toml#L36-L44).


https://github.com/pysal/momepy/blob/b4a415677fe3b2c0f9ce5f9700833cb88fae583f/pyproject.toml#L36-L44



* 