### PR TITLE
update warnings for ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.255"
+    rev: "v0.0.257"
     hooks:
       - id: ruff
 

--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -382,6 +382,7 @@ class Tessellation:
                     f"during generation - unique_id: {self.collapsed}."
                 ),
                 category=UserWarning,
+                stacklevel=1,
             )
 
         # check MultiPolygons - usually caused by error in input geometry
@@ -396,6 +397,7 @@ class Tessellation:
                     f"elements: {list(self.multipolygons)}."
                 ),
                 category=UserWarning,
+                stacklevel=1,
             )
 
     def _enclosed_tessellation(
@@ -474,6 +476,7 @@ class Tessellation:
                         f"Setting `use_dask={use_dask}`."
                     ),
                     category=UserWarning,
+                    stacklevel=1,
                 )
 
         if use_dask:
@@ -758,6 +761,7 @@ def get_network_id(left, right, network_id, min_size=100, verbose=True):
                 f"`min_size``. {sum(series.isnull())} affected elements."
             ),
             category=UserWarning,
+            stacklevel=1,
         )
     return series
 

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -61,12 +61,14 @@ def _generate_primal(graph, gdf_network, fields, multigraph, oneway_column=None)
         warnings.warn(
             message=msg % "The given network does not contain any LineString.",
             category=RuntimeWarning,
+            stacklevel=1,
         )
 
     if len(gdf_network.geom_type.unique()) > 1:
         warnings.warn(
             message=msg % "The given network consists of multiple geometry types.",
             category=RuntimeWarning,
+            stacklevel=1,
         )
 
     key = 0
@@ -425,7 +427,9 @@ def nx_to_gdf(
 
     if not primal:
         warnings.warn(
-            message="Approach is not set. Defaulting to 'primal'.", category=UserWarning
+            message="Approach is not set. Defaulting to 'primal'.",
+            category=UserWarning,
+            stacklevel=1,
         )
 
     for nid, n in enumerate(net):


### PR DESCRIPTION
This PR supercedes #475 and explicitly adds the `stacklevel` keyword to `warnings.warn()`. 