### PR TITLE
TST: fix a flaky test in Count

### DIFF
--- a/momepy/tests/test_intensity.py
+++ b/momepy/tests/test_intensity.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from libpysal.weights import Queen
 from shapely.geometry import Point
+from pandas.testing import assert_series_equal
 
 import momepy as mm
 
@@ -86,9 +87,14 @@ class TestIntensity:
         weis = mm.Count(
             self.df_streets, self.df_buildings, "nID", "nID", weighted=True
         ).series
-        check_eib = [13, 14, 8, 26, 24, 17, 23, 19]
+        check_eib = (
+            self.df_buildings.drop(columns="bID")
+            .sjoin(self.blocks)["bID"]
+            .value_counts()
+            .sort_index()
+        )
         check_weib = pytest.approx(0.00040170607189453996)
-        assert eib.tolist() == check_eib
+        assert_series_equal(check_eib, eib, check_names=False)
         assert weib.mean() == check_weib
         assert weis.mean() == pytest.approx(0.020524232642849215)
 

--- a/momepy/tests/test_intensity.py
+++ b/momepy/tests/test_intensity.py
@@ -88,8 +88,7 @@ class TestIntensity:
             self.df_streets, self.df_buildings, "nID", "nID", weighted=True
         ).series
         check_eib = (
-            self.df_buildings.drop(columns="bID")
-            .sjoin(self.blocks)["bID"]
+            gpd.sjoin(self.df_buildings.drop(columns="bID"), self.blocks)["bID"]
             .value_counts()
             .sort_index()
         )


### PR DESCRIPTION
We have a CI in dev env. The result is correct but the order of rows in blocks is coming different from some geopandas operation. 

We don't really care about that so I am just replacing the test with something a bit more robust.

I also noticed that the whole `Blocks` algo would deserve a bit of refactoring but that is a problem for another time.