### PR TITLE
CI/TST: fix test, rm log action, ruff-format

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,13 +53,3 @@ jobs:
           ci/envs/test_user_guide.sh
 
       - uses: codecov/codecov-action@v3
-
-      - name: Generate and publish the report
-        if: |
-          failure()
-          && github.event_name != 'pull_request'
-          && github.repository == 'pysal/momepy'
-          && steps.run_tests.outcome == 'failure'
-        uses: xarray-contrib/issue-from-pytest-log@v1
-        with:
-          log-path: pytest-log.jsonl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,10 @@
 files: 'momepy\/'
 repos:
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-        language_version: python3
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.9"
+    rev: "v0.1.11"
     hooks:
       - id: ruff
+      - id: ruff-format
 
 ci:
   autofix_prs: false

--- a/momepy/preprocessing.py
+++ b/momepy/preprocessing.py
@@ -1113,7 +1113,7 @@ class FaceArtifacts:
                 [gdf.unary_union]
             ).geoms,  # get parts of the collection from polygonize
             crs=gdf.crs,
-        ).explode(ignore_index=True)  # shoudln't be needed but doesn't hurt to ensure
+        ).explode(ignore_index=True)  # shouldn't be needed but doesn't hurt to ensure
 
         # Store geometries as a GeoDataFrame
         self.polygons = gpd.GeoDataFrame(geometry=polygons)

--- a/momepy/preprocessing.py
+++ b/momepy/preprocessing.py
@@ -1113,9 +1113,7 @@ class FaceArtifacts:
                 [gdf.unary_union]
             ).geoms,  # get parts of the collection from polygonize
             crs=gdf.crs,
-        ).explode(
-            ignore_index=True
-        )  # shoudln't be needed but doesn't hurt to ensure
+        ).explode(ignore_index=True)  # shoudln't be needed but doesn't hurt to ensure
 
         # Store geometries as a GeoDataFrame
         self.polygons = gpd.GeoDataFrame(geometry=polygons)

--- a/momepy/shape.py
+++ b/momepy/shape.py
@@ -1143,7 +1143,7 @@ class CentroidCorners:
     --------
     >>> ccd = momepy.CentroidCorners(buildings_df)
     100%|██████████| 144/144 [00:00<00:00, 846.58it/s]
-    >>> buildings_df['ccd_means'] = ccd.means
+    >>> buildings_df['ccd_means'] = ccd.mean
     >>> buildings_df['ccd_stdev'] = ccd.std
     >>> buildings_df['ccd_means'][0]
     15.961531913184833

--- a/momepy/tests/test_elements.py
+++ b/momepy/tests/test_elements.py
@@ -77,9 +77,20 @@ class TestElements:
         x = np.mean([b[0], b[2]])
         y = np.mean([b[1], b[3]])
 
-        df.loc[144] = [145, Polygon([(x, y), (x, y + 1), (x + 1, y)])]
-        df.loc[145] = [146, MultiPoint([(x, y), (x + 1, y)]).buffer(0.55)]
-        df.loc[146] = [147, affinity.rotate(df.geometry.iloc[0], 12)]
+        df = pd.concat(
+            [
+                df,
+                gpd.GeoDataFrame(
+                    {"uID": [145, 146, 147]},
+                    geometry=[
+                        Polygon([(x, y), (x, y + 1), (x + 1, y)]),
+                        MultiPoint([(x, y), (x + 1, y)]).buffer(0.55),
+                        affinity.rotate(df.geometry.iloc[0], 12),
+                    ],
+                    index=[144, 145, 146],
+                ),
+            ]
+        )
 
         with pytest.warns(
             UserWarning, match="Tessellation does not fully match buildings."

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -336,7 +336,11 @@ def _dual_to_gdf(net):
 
 
 def nx_to_gdf(
-    net, points=True, lines=True, spatial_weights=False, nodeID="nodeID"  # noqa
+    net,
+    points=True,
+    lines=True,
+    spatial_weights=False,
+    nodeID="nodeID",  # noqa: N803
 ):
     """
     Convert a ``networkx.Graph`` to a LineString GeoDataFrame and Point GeoDataFrame.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ include = ["momepy", "momepy.*"]
 [tool.setuptools.package-data]
 momepy = ["datasets/bubenec.gpkg", "datasets/tests.gpkg"]
 
-[tool.black]
-line-length = 88
-
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]


### PR DESCRIPTION
Fixing the issue in dev CI (that is actually a regression on dev GeoPandas but we can avoid it) and removing the xarray-contrib/issue-from-pytest-log action that does not work.

edit: also resolves #531
edit2: adopt ruff-format