### PR TITLE
CI: test on Apple Silicon

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,6 +27,8 @@ jobs:
           - environment-file: ci/envs/312-latest.yaml
             os: macos-latest
           - environment-file: ci/envs/312-latest.yaml
+            os: macos-14 # Apple Silicon
+          - environment-file: ci/envs/312-latest.yaml
             os: windows-latest
     defaults:
       run:


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/