### PR TITLE
gdf2osmnx

### DIFF
--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -20,7 +20,6 @@ from shapely.geometry import LineString, MultiLineString
 
 
 class COINS:
-
     """
     Calculates natural continuity and hierarchy of street networks in a given
     GeoDataFrame using the COINS algorithm.

--- a/momepy/distribution.py
+++ b/momepy/distribution.py
@@ -411,7 +411,6 @@ class CellAlignment:
 
 
 class Alignment:
-
     """
     Calculate the mean deviation of solar orientation of objects on adjacent cells
     from an object.

--- a/momepy/preprocessing.py
+++ b/momepy/preprocessing.py
@@ -150,9 +150,9 @@ def preprocess(
                         geoms.append(blg[blg["mm_uid"] == j].iloc[0].geometry)
                         blg.drop(blg[blg["mm_uid"] == j].index[0], inplace=True)
                 new_geom = shapely.ops.unary_union(geoms)
-                blg.loc[
-                    blg.loc[blg["mm_uid"] == key].index[0], blg.geometry.name
-                ] = new_geom
+                blg.loc[blg.loc[blg["mm_uid"] == key].index[0], blg.geometry.name] = (
+                    new_geom
+                )
 
         blg.drop(delete, inplace=True)
     return blg[buildings.columns]
@@ -1568,7 +1568,9 @@ class FaceArtifacts:
                 [gdf.unary_union]
             ).geoms,  # get parts of the collection from polygonize
             crs=gdf.crs,
-        ).explode(ignore_index=True)  # shouldn't be needed but doesn't hurt to ensure
+        ).explode(
+            ignore_index=True
+        )  # shouldn't be needed but doesn't hurt to ensure
 
         # Store geometries as a GeoDataFrame
         self.polygons = gpd.GeoDataFrame(geometry=polygons)

--- a/momepy/shape.py
+++ b/momepy/shape.py
@@ -1258,9 +1258,11 @@ class Linearity:
         self.gdf = gdf
 
         euclidean = gdf.geometry.apply(
-            lambda geom: self._dist(geom.coords[0], geom.coords[-1])
-            if geom.geom_type == "LineString"
-            else np.nan
+            lambda geom: (
+                self._dist(geom.coords[0], geom.coords[-1])
+                if geom.geom_type == "LineString"
+                else np.nan
+            )
         )
         self.series = euclidean / gdf.geometry.length
 

--- a/momepy/tests/test_preprocess.py
+++ b/momepy/tests/test_preprocess.py
@@ -196,6 +196,7 @@ class TestPreprocessing:
                 rebuild_edges_method="banana",
             )
 
+
 def test_FaceArtifacts():
     pytest.importorskip("esda")
     osmnx = pytest.importorskip("osmnx")

--- a/momepy/tests/test_utils.py
+++ b/momepy/tests/test_utils.py
@@ -54,6 +54,11 @@ class TestUtils:
             ValueError, match="Approach 'nonexistent' is not supported."
         ):
             mm.gdf_to_nx(self.df_streets, approach="nonexistent")
+        with pytest.raises(
+            ValueError,
+            match="OSMnx-compatible graphs must be directed, of multigraph type, and using the primal approach.",
+        ):
+            mm.gdf_to_nx(self.df_streets, approach="dual", osmnx_like=True)
 
         nx = mm.gdf_to_nx(self.df_streets, multigraph=False)
         assert isinstance(nx, networkx.Graph)
@@ -69,6 +74,12 @@ class TestUtils:
         assert isinstance(nx, networkx.MultiDiGraph)
         assert nx.number_of_nodes() == 29
         assert nx.number_of_edges() == 35
+
+        nx = mm.gdf_to_nx(self.df_streets, directed=True, osmnx_like=True)
+        assert isinstance(nx, networkx.MultiDiGraph)
+        assert nx.number_of_nodes() == 83
+        assert nx.number_of_edges() == 89
+        assert networkx.degree_histogram(nx) == [0, 11, 58, 6, 7, 1]
 
         self.df_streets["oneway"] = True
         self.df_streets.loc[0, "oneway"] = False  # first road section is bidirectional

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -81,7 +81,7 @@ def _generate_primal(
 
     if osmnx_like:
 
-        gdf_network["geometry"] = gdf_network["geometry"].apply(
+        gdf_network.geometry = gdf_network.geometry.apply(
             lambda x: linemerge(x) if x.geom_type == "MultiLineString" else x
         )
         gdf_network = gdf_network.explode(index_parts=False)

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -50,7 +50,7 @@ def _angle(a, b, c):
 
 def _make_edgetuples(nodelist):
     """Zip list of nodes into list of edgetuples. Helper function for _generate_primal"""
-    return [z for z in zip(nodelist, nodelist[1:])]
+    return [z for z in zip(nodelist[:-1], nodelist[1:], strict=True)]
 
 
 def _generate_primal(


### PR DESCRIPTION
Added the `osmnx_like` keyword to `gdf_to_nx()`. If `osmnx_like=True`, within `_generate_primal`:
* *first*, add all unique node coordinates as nodes to `net` with unique dummy IDs 
*  break each linestring in gdf into two-point linestrings
* for each two-point linestring, find corresponding node IDs (u,v)
* *only then*, add edges as (u,v) pairs to graph _iteratively_, at each step checking whether (u,v) already exists in graph (if so, key+=1)
* the output MultiDiGraph from `gdf_to_nx()`now works as input for `osmnx.simplify_graph()`