### PR TITLE
REF: functional implementation of shape module

### DIFF
--- a/momepy/__init__.py
+++ b/momepy/__init__.py
@@ -8,6 +8,7 @@ from .distribution import *
 from .diversity import *
 from .elements import *
 from .functional._dimension import *
+from .functional._shape import *
 from .graph import *
 from .intensity import *
 from .preprocessing import *

--- a/momepy/functional/_shape.py
+++ b/momepy/functional/_shape.py
@@ -70,7 +70,7 @@ def form_factor(
 def fractal_dimension(
     geometry: GeoDataFrame | GeoSeries,
 ) -> Series:
-    """Calculates fractal dimensionbased on area and perimeter.
+    """Calculates fractal dimension based on area and perimeter.
 
     .. math::
         {2log({{perimeter} \\over {4}})} \\over log(area)

--- a/momepy/functional/_shape.py
+++ b/momepy/functional/_shape.py
@@ -317,9 +317,7 @@ def squareness(
     Series
     """
     if not GPD_013:
-        raise ImportError(
-            "momepy.centroid_corner_distance requires geopandas 0.13 or later. "
-        )
+        raise ImportError("momepy.squareness requires geopandas 0.13 or later. ")
 
     def _squareness(points: DataFrame, eps: float) -> int:
         pts = points.values[:-1]

--- a/momepy/functional/_shape.py
+++ b/momepy/functional/_shape.py
@@ -321,7 +321,7 @@ def squareness(
     if not GPD_013:
         raise ImportError("momepy.squareness requires geopandas 0.13 or later. ")
 
-    def _squareness(points: DataFrame, eps: float) -> int:
+    def _squareness(points: DataFrame, eps: float):
         pts = points.values[:-1]
         true_angles, degrees = _true_angles_mask(pts, eps=eps, return_degrees=True)
 

--- a/momepy/functional/_shape.py
+++ b/momepy/functional/_shape.py
@@ -1,0 +1,375 @@
+import numpy as np
+import shapely
+from geopandas import GeoDataFrame, GeoSeries
+from numpy.typing import NDArray
+from pandas import DataFrame, Series
+
+from momepy.functional import _dimension
+
+__all__ = [
+    "form_factor",
+    "fractal_dimension",
+    "volume_facade_ratio",
+    "circular_compactness",
+    "square_compactness",
+    "convexity",
+    "courtyard_index",
+    "rectangularity",
+    "shape_index",
+    "corners",
+    "squareness",
+]
+
+
+def form_factor(
+    geometry: GeoDataFrame | GeoSeries,
+    height: NDArray[np.float_] | Series,
+) -> Series:
+    """Calculates the form factor of each object given its geometry and height.
+
+    .. math::
+        surface \\over {volume^{2 \\over 3}}
+
+    where
+
+    .. math::
+        surface = (perimeter * height) + area
+
+    Adapted from :cite:`bourdic2012`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+    height : NDArray[np.float_] | Series
+        array of heights
+
+    Returns
+    -------
+    Series
+    """
+    area = geometry.area
+    volume = area * height
+    surface = (geometry.length * height) + geometry.area
+    zeros = volume == 0
+    res = np.empty(len(geometry))
+    res[zeros] = np.nan
+    res[~zeros] = surface[~zeros] / (volume[~zeros] ** (2 / 3))
+    return Series(res, index=geometry.index, name="form_factor")
+
+
+def fractal_dimension(
+    area: NDArray[np.float_] | Series,
+    perimeter: NDArray[np.float_] | Series,
+) -> NDArray[np.float_] | Series:
+    """Calculates fractal dimensionbased on area and perimeter.
+
+    .. math::
+        {2log({{perimeter} \\over {4}})} \\over log(area)
+
+    Based on :cite:`mcgarigal1995fragstats`.
+
+    Parameters
+    ----------
+    area : NDArray[np.float_] | Series
+        array of areas
+    perimeter : NDArray[np.float_] | Series
+        array of perimeters
+
+    Returns
+    -------
+    NDArray[np.float_] | Series
+        array of a type depending on the input
+    """
+    return (2 * np.log(perimeter / 4)) / np.log(area)
+
+
+def volume_facade_ratio(
+    geometry: GeoDataFrame | GeoSeries,
+    height: NDArray[np.float_] | Series,
+) -> Series:
+    """
+    Calculates the volume-to-facade ratio of each object given its geometry and height.
+
+    .. math::
+        volume \\over perimeter * height
+
+    Adapted from :cite:`schirmer2015`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+    height : NDArray[np.float_] | Series
+        array of heights
+
+    Returns
+    -------
+    Series
+    """
+    return (geometry.area * height) / (geometry.length * height)
+
+
+def circular_compactness(geometry: GeoDataFrame | GeoSeries) -> Series:
+    """Calculates the circular compactness of each object given its geometry.
+
+    .. math::
+        area \\over \\textit{area of enclosing circle}
+
+    Adapted from :cite:`dibble2017`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+
+    Returns
+    -------
+    Series
+    """
+    return geometry.area / (
+        np.pi * shapely.minimum_bounding_radius(geometry.geometry) ** 2
+    )
+
+
+def square_compactness(geometry: GeoDataFrame | GeoSeries) -> Series:
+    """Calculates the square compactness of each object given its geometry.
+
+    .. math::
+        \\begin{equation*}
+        \\left(\\frac{4 \\sqrt{area}}{perimeter}\\right) ^ 2
+        \\end{equation*}
+
+    Adapted from :cite:`feliciotti2018`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+
+    Returns
+    -------
+    Series
+    """
+    return ((np.sqrt(geometry.area) * 4) / geometry.length) ** 2
+
+
+def convexity(geometry: GeoDataFrame | GeoSeries) -> Series:
+    """Calculates the convexity of each object given its geometry.
+
+    .. math::
+        \\frac{\\textit{area}}{\\textit{area of convex hull}}
+
+    Adapted from :cite:`dibble2017`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+
+    Returns
+    -------
+    Series
+    """
+    return geometry.area / geometry.geometry.convex_hull.area
+
+
+def courtyard_index(
+    geometry: GeoDataFrame | GeoSeries,
+    courtyard_area: NDArray[np.float_] | Series | None = None,
+) -> Series:
+    """Calculates the courtyard index of each object given its geometry.
+
+    .. math::
+        \\textit{area of courtyards} \\over \\textit{total area}
+
+    Adapted from :cite:`schirmer2015`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+    courtyard_area : NDArray[np.float_] | Series | None, optional
+        array of courtyard areas. If None, it will be calculated, by default None
+
+    Returns
+    -------
+    Series
+    """
+    if courtyard_area is None:
+        courtyard_area = _dimension.courtyard_area(geometry)
+    return courtyard_area / geometry.area
+
+
+def rectangularity(geometry: GeoDataFrame | GeoSeries) -> Series:
+    """Calculates the rectangularity of each object given its geometry.
+
+    .. math::
+        \\frac{\\textit{area}}{\\textit{area of minimum bounding rectangle}}
+
+    Adapted from :cite:`dibble2017`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+
+    Returns
+    -------
+    Series
+    """
+    return geometry.area / shapely.minimum_rotated_rectangle(geometry.geometry).area
+
+
+def shape_index(
+    geometry: GeoDataFrame | GeoSeries,
+    longest_axis_length: NDArray[np.float_] | Series | None = None,
+) -> Series:
+    """Calculates the shape index of each object given its geometry.
+
+    .. math::
+        {\\sqrt{{area} \\over {\\pi}}} \\over {0.5 * \\textit{longest axis}}
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+         A GeoDataFrame or GeoSeries containing polygons to analyse.
+    longest_axis_length : NDArray[np.float_] | Series | None, optional
+        array of longest axis lengths. If None, it will be calculated, by default None
+
+    Returns
+    -------
+    Series
+    """
+    if longest_axis_length is None:
+        longest_axis_length = _dimension.longest_axis_length(geometry)
+    return np.sqrt(geometry.area / np.pi) / (0.5 * longest_axis_length)
+
+
+def corners(
+    geometry: GeoDataFrame | GeoSeries,
+    eps: float = 10,
+    include_interiors: bool = False,
+) -> Series:
+    """Calculates the number of corners of each object given its geometry.
+
+    As a corner is considered a point where the angle between two consecutive segments
+    deviates from 180 degrees by more than ``eps``.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+    eps : float, optional
+        Deviation from 180 degrees to consider a corner, by default 10
+    include_interiors : bool, optional
+        If True, polygon interiors are included in the calculation. If False, only
+        exterior is considered, by default False
+
+    Returns
+    -------
+    Series
+    """
+
+    def _count_corners(points: DataFrame, eps: float) -> int:
+        points = points.values[:-1]
+        a = np.roll(points, 1, axis=0)
+        b = points
+        c = np.roll(points, -1, axis=0)
+
+        ba = a - b
+        bc = c - b
+
+        cosine_angle = np.sum(ba * bc, axis=1) / (
+            np.linalg.norm(ba, axis=1) * np.linalg.norm(bc, axis=1)
+        )
+        angles = np.arccos(cosine_angle)
+        degrees = np.degrees(angles)
+
+        true_angles = np.logical_or(degrees <= 180 - eps, degrees >= 180 + eps)
+        corners = np.count_nonzero(true_angles)
+
+        return corners
+
+    if include_interiors:
+        coords = geometry.get_coordinates(index_parts=False)
+    else:
+        coords = geometry.exterior.get_coordinates(index_parts=False)
+
+    return coords.groupby(level=0).apply(_count_corners, eps=eps)
+
+
+def squareness(
+    geometry: GeoDataFrame | GeoSeries,
+    eps: float = 10,
+    include_interiors: bool = False,
+) -> Series:
+    """Calculates the squareness of each object given its geometry.
+
+    Squareness is a mean deviation of angles at corners from 90 degrees.
+
+    As a corner is considered a point where the angle between two consecutive segments
+    deviates from 180 degrees by more than ``eps``.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+    eps : float, optional
+        Deviation from 180 degrees to consider a corner, by default 10
+    include_interiors : bool, optional
+        If True, polygon interiors are included in the calculation. If False, only
+        exterior is considered, by default False
+
+    Returns
+    -------
+    Series
+    """
+
+    def _squareness(points: DataFrame, eps: float) -> int:
+        points = points.values[:-1]
+        a = np.roll(points, 1, axis=0)
+        b = points
+        c = np.roll(points, -1, axis=0)
+
+        ba = a - b
+        bc = c - b
+
+        cosine_angle = np.sum(ba * bc, axis=1) / (
+            np.linalg.norm(ba, axis=1) * np.linalg.norm(bc, axis=1)
+        )
+        angles = np.arccos(cosine_angle)
+        degrees = np.degrees(angles)
+
+        true_angles = np.logical_or(degrees <= 180 - eps, degrees >= 180 + eps)
+
+        return np.nanmean(np.abs(90 - degrees[true_angles]))
+
+    if include_interiors:
+        coords = geometry.get_coordinates(index_parts=False)
+    else:
+        coords = geometry.exterior.get_coordinates(index_parts=False)
+
+    return coords.groupby(level=0).apply(_squareness, eps=eps)
+
+
+def eri(geometry: GeoDataFrame | GeoSeries) -> Series:
+    """Calculates the equivalent rectangular index of each object given its geometry.
+
+    .. math::
+        \\sqrt{{area} \\over \\textit{area of bounding rectangle}} *
+        {\\textit{perimeter of bounding rectangle} \\over {perimeter}}
+
+    Based on :cite:`basaraner2017`.
+
+    Parameters
+    ----------
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
+
+    Returns
+    -------
+    Series
+    """
+    bbox = shapely.minimum_rotated_rectangle(geometry.geometry)
+    return np.sqrt(geometry.area / bbox.area) * (bbox.length / geometry.length)

--- a/momepy/functional/_shape.py
+++ b/momepy/functional/_shape.py
@@ -130,7 +130,7 @@ def circular_compactness(geometry: GeoDataFrame | GeoSeries) -> Series:
     Series
     """
     return geometry.area / (
-        np.pi * shapely.minimum_bounding_radius(geometry.geometry) ** 2
+        np.pi * shapely.minimum_bounding_radius(geometry.geometry.array) ** 2
     )
 
 
@@ -220,7 +220,9 @@ def rectangularity(geometry: GeoDataFrame | GeoSeries) -> Series:
     -------
     Series
     """
-    return geometry.area / shapely.minimum_rotated_rectangle(geometry.geometry).area
+    return geometry.area / shapely.area(
+        shapely.minimum_rotated_rectangle(geometry.geometry.array)
+    )
 
 
 def shape_index(
@@ -351,8 +353,10 @@ def equivalent_rectangular_index(geometry: GeoDataFrame | GeoSeries) -> Series:
     -------
     Series
     """
-    bbox = shapely.minimum_rotated_rectangle(geometry.geometry)
-    return np.sqrt(geometry.area / bbox.area) * (bbox.length / geometry.length)
+    bbox = shapely.minimum_rotated_rectangle(geometry.geometry.array)
+    return np.sqrt(geometry.area / shapely.area(bbox)) * (
+        shapely.length(bbox) / geometry.length
+    )
 
 
 def elongation(geometry: GeoDataFrame | GeoSeries) -> Series:
@@ -377,9 +381,9 @@ def elongation(geometry: GeoDataFrame | GeoSeries) -> Series:
     -------
     Series
     """
-    bbox = shapely.minimum_rotated_rectangle(geometry.geometry)
-    a = bbox.area
-    p = bbox.length
+    bbox = shapely.minimum_rotated_rectangle(geometry.geometry.array)
+    a = shapely.area(bbox)
+    p = shapely.length(bbox)
     sqrt = np.maximum(p**2 - 16 * a, 0)
 
     elo1 = ((p - np.sqrt(sqrt)) / 4) / ((p / 2) - ((p - np.sqrt(sqrt)) / 4))
@@ -461,8 +465,9 @@ def linearity(geometry: GeoDataFrame | GeoSeries) -> Series:
     Series
     """
     return (
-        shapely.get_point(geometry.geometry, 0).distance(
-            shapely.get_point(geometry.geometry, -1)
+        shapely.distance(
+            shapely.get_point(geometry.geometry.array, 0),
+            shapely.get_point(geometry.geometry.array, -1),
         )
         / geometry.length
     )

--- a/momepy/functional/_shape.py
+++ b/momepy/functional/_shape.py
@@ -9,7 +9,7 @@ from momepy.functional import _dimension
 __all__ = [
     "form_factor",
     "fractal_dimension",
-    "volume_facade_ratio",
+    "facade_ratio",
     "circular_compactness",
     "square_compactness",
     "convexity",
@@ -18,6 +18,11 @@ __all__ = [
     "shape_index",
     "corners",
     "squareness",
+    "eri",
+    "elongation",
+    "centroid_corner_distance",
+    "linearity",
+    "cwa",
 ]
 
 
@@ -59,9 +64,8 @@ def form_factor(
 
 
 def fractal_dimension(
-    area: NDArray[np.float_] | Series,
-    perimeter: NDArray[np.float_] | Series,
-) -> NDArray[np.float_] | Series:
+    geometry: GeoDataFrame | GeoSeries,
+) -> Series:
     """Calculates fractal dimensionbased on area and perimeter.
 
     .. math::
@@ -71,28 +75,24 @@ def fractal_dimension(
 
     Parameters
     ----------
-    area : NDArray[np.float_] | Series
-        array of areas
-    perimeter : NDArray[np.float_] | Series
-        array of perimeters
+    geometry : GeoDataFrame | GeoSeries
+        A GeoDataFrame or GeoSeries containing polygons to analyse.
 
     Returns
     -------
-    NDArray[np.float_] | Series
-        array of a type depending on the input
+    Series
     """
-    return (2 * np.log(perimeter / 4)) / np.log(area)
+    return (2 * np.log(geometry.length / 4)) / np.log(geometry.area)
 
 
-def volume_facade_ratio(
+def facade_ratio(
     geometry: GeoDataFrame | GeoSeries,
-    height: NDArray[np.float_] | Series,
 ) -> Series:
     """
-    Calculates the volume-to-facade ratio of each object given its geometry and height.
+    Calculates the facade ratio of each object given its geometry.
 
     .. math::
-        volume \\over perimeter * height
+        area \\over perimeter
 
     Adapted from :cite:`schirmer2015`.
 
@@ -100,14 +100,12 @@ def volume_facade_ratio(
     ----------
     geometry : GeoDataFrame | GeoSeries
         A GeoDataFrame or GeoSeries containing polygons to analyse.
-    height : NDArray[np.float_] | Series
-        array of heights
 
     Returns
     -------
     Series
     """
-    return (geometry.area * height) / (geometry.length * height)
+    return geometry.area / geometry.length
 
 
 def circular_compactness(geometry: GeoDataFrame | GeoSeries) -> Series:

--- a/momepy/functional/tests/test_shape.py
+++ b/momepy/functional/tests/test_shape.py
@@ -2,7 +2,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_index_equal
+from pandas.testing import assert_index_equal, assert_series_equal
 
 import momepy as mm
 
@@ -30,7 +30,7 @@ class TestDimensions:
             "min": 4.7712411918919,
             "max": 9.0604207122634,
         }
-        r = mm.form_factor(self.df_buildings.geometry, self.df_buildings.height)
+        r = mm.form_factor(self.df_buildings, self.df_buildings.height)
         assert_result(r, expected, self.df_buildings)
 
     def test_fractal_dimension(self):
@@ -40,7 +40,7 @@ class TestDimensions:
             "min": 0.9961153485808,
             "max": 1.1823500218800869,
         }
-        r = mm.fractal_dimension(self.df_buildings.geometry)
+        r = mm.fractal_dimension(self.df_buildings)
         assert_result(r, expected, self.df_buildings)
 
     def test_facade_ratio(self):
@@ -50,5 +50,101 @@ class TestDimensions:
             "min": 1.693082337025171,
             "max": 11.314007604595293,
         }
-        r = mm.facade_ratio(self.df_buildings.geometry)
+        r = mm.facade_ratio(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_circular_compactness(self):
+        expected = {
+            "mean": 0.5690762180557374,
+            "sum": 81.94697540002619,
+            "min": 0.2790908141757502,
+            "max": 0.7467862040050506,
+        }
+        r = mm.circular_compactness(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_square_compactness(self):
+        expected = {
+            "mean": 0.8486134470818577,
+            "sum": 122.20033637978752,
+            "min": 0.18260442238858857,
+            "max": 1.0179729958596555,
+        }
+        r = mm.square_compactness(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_convexity(self):
+        expected = {
+            "mean": 0.941622590878818,
+            "sum": 135.5936530865498,
+            "min": 0.5940675324809443,
+            "max": 1,
+        }
+        r = mm.convexity(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_courtyard_index(self):
+        expected = {
+            "mean": 0.0011531885929613557,
+            "sum": 0.16605915738643523,
+            "min": 0,
+            "max": 0.16605915738643523,
+        }
+        r = mm.courtyard_index(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+        r2 = mm.courtyard_index(self.df_buildings, mm.courtyard_area(self.df_buildings))
+        assert_series_equal(r, r2)
+
+    def test_rectangularity(self):
+        expected = {
+            "mean": 0.8867686143851342,
+            "sum": 127.69468047145932,
+            "min": 0.4354516872480972,
+            "max": 0.9994000284783504,
+        }
+        r = mm.rectangularity(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_shape_index(self):
+        expected = {
+            "mean": 0.7517554336770522,
+            "sum": 108.25278244949553,
+            "min": 0.5282904638319247,
+            "max": 0.8641679258136411,
+        }
+        r = mm.shape_index(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+        r2 = mm.shape_index(
+            self.df_buildings, mm.longest_axis_length(self.df_buildings)
+        )
+        assert_series_equal(r, r2)
+
+    def test_corners(self):
+        expected = {
+            "mean": 10.3125,
+            "sum": 1485,
+            "min": 4,
+            "max": 43,
+        }
+        r = mm.corners(self.df_buildings)
+        assert_result(r, expected, self.df_buildings)
+
+        expected = {
+            "mean": 10.993055555555555,
+            "sum": 1583,
+            "min": 4,
+            "max": 46,
+        }
+        r = mm.corners(self.df_buildings, eps=1)
+        assert_result(r, expected, self.df_buildings)
+
+        expected = {
+            "mean": 10.340277777777779,
+            "sum": 1489,
+            "min": 4,
+            "max": 43,
+        }
+        r = mm.corners(self.df_buildings, include_interiors=True)
         assert_result(r, expected, self.df_buildings)

--- a/momepy/functional/tests/test_shape.py
+++ b/momepy/functional/tests/test_shape.py
@@ -389,11 +389,13 @@ class TestEquality:
         ).series
         assert_series_equal(new, old, check_names=False)
 
+    @pytest.mark.skipif(not GPD_013, reason="get_coordinates() not available")
     def test_corners(self):
         new = mm.corners(self.df_buildings)
         old = mm.Corners(self.df_buildings).series
         assert_series_equal(new, old, check_names=False)
 
+    @pytest.mark.skipif(not GPD_013, reason="get_coordinates() not available")
     def test_squareness(self):
         new = mm.squareness(self.df_buildings, eps=5)
         old = mm.Squareness(self.df_buildings).series
@@ -409,6 +411,7 @@ class TestEquality:
         old = mm.Elongation(self.df_streets).series
         assert_series_equal(new, old, check_names=False)
 
+    @pytest.mark.skipif(not GPD_013, reason="get_coordinates() not available")
     def test_centroid_corner_distance(self):
         new = mm.centroid_corner_distance(self.df_buildings)
         ccd = mm.CentroidCorners(self.df_buildings)

--- a/momepy/functional/tests/test_shape.py
+++ b/momepy/functional/tests/test_shape.py
@@ -18,12 +18,11 @@ def assert_result(result, expected, geometry):
     assert_index_equal(result.index, geometry.index)
 
 
-class TestDimensions:
+class TestShape:
     def setup_method(self):
         test_file_path = mm.datasets.get_path("bubenec")
         self.df_buildings = gpd.read_file(test_file_path, layer="buildings")
         self.df_streets = gpd.read_file(test_file_path, layer="streets")
-        self.df_tessellation = gpd.read_file(test_file_path, layer="tessellation")
         self.df_buildings["height"] = np.linspace(10.0, 30.0, 144)
 
     def test_form_factor(self):
@@ -328,3 +327,102 @@ class TestDimensions:
             self.df_buildings, mm.longest_axis_length(self.df_buildings)
         )
         assert_series_equal(r, r2)
+
+
+class TestEquality:
+    def setup_method(self):
+        test_file_path = mm.datasets.get_path("bubenec")
+        self.df_buildings = gpd.read_file(test_file_path, layer="buildings")
+        self.df_streets = gpd.read_file(test_file_path, layer="streets")
+        self.df_buildings["height"] = np.linspace(10.0, 30.0, 144)
+
+    def test_form_factor(self):
+        new = mm.form_factor(self.df_buildings, self.df_buildings.height)
+        old = mm.FormFactor(
+            self.df_buildings,
+            volumes=self.df_buildings.height * self.df_buildings.area,
+            heights=self.df_buildings.height,
+        ).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_fractal_dimension(self):
+        new = mm.fractal_dimension(self.df_buildings)
+        old = mm.FractalDimension(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_facade_ratio(self):
+        new = mm.facade_ratio(self.df_buildings)
+        old = mm.VolumeFacadeRatio(self.df_buildings, "height").series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_circular_compactness(self):
+        new = mm.circular_compactness(self.df_buildings)
+        old = mm.CircularCompactness(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_square_compactness(self):
+        new = mm.square_compactness(self.df_buildings)
+        old = mm.SquareCompactness(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_convexity(self):
+        new = mm.convexity(self.df_buildings)
+        old = mm.Convexity(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_courtyard_index(self):
+        new = mm.courtyard_index(self.df_buildings)
+        old = mm.CourtyardIndex(
+            self.df_buildings, mm.courtyard_area(self.df_buildings)
+        ).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_rectangularity(self):
+        new = mm.rectangularity(self.df_buildings)
+        old = mm.Rectangularity(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_shape_index(self):
+        new = mm.shape_index(self.df_buildings)
+        old = mm.ShapeIndex(
+            self.df_buildings, mm.longest_axis_length(self.df_buildings)
+        ).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_corners(self):
+        new = mm.corners(self.df_buildings)
+        old = mm.Corners(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_squareness(self):
+        new = mm.squareness(self.df_buildings, eps=5)
+        old = mm.Squareness(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_equivalent_rectangular_index(self):
+        new = mm.equivalent_rectangular_index(self.df_buildings)
+        old = mm.EquivalentRectangularIndex(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_elongation(self):
+        new = mm.elongation(self.df_streets)
+        old = mm.Elongation(self.df_streets).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_centroid_corner_distance(self):
+        new = mm.centroid_corner_distance(self.df_buildings)
+        ccd = mm.CentroidCorners(self.df_buildings)
+        mean = ccd.mean
+        std = ccd.std
+        old = pd.DataFrame({"mean": mean, "std": std})
+        assert_frame_equal(new, old, check_names=False)
+
+    def test_linearity(self):
+        new = mm.linearity(self.df_streets)
+        old = mm.Linearity(self.df_streets).series
+        assert_series_equal(new, old, check_names=False)
+
+    def test_compactness_weighted_axis(self):
+        new = mm.compactness_weighted_axis(self.df_buildings)
+        old = mm.CompactnessWeightedAxis(self.df_buildings).series
+        assert_series_equal(new, old, check_names=False)

--- a/momepy/functional/tests/test_shape.py
+++ b/momepy/functional/tests/test_shape.py
@@ -1,0 +1,54 @@
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_index_equal
+
+import momepy as mm
+
+
+def assert_result(result, expected, geometry):
+    """Check the expected values and types of the result."""
+    for key, value in expected.items():
+        assert getattr(result, key)() == pytest.approx(value)
+    assert isinstance(result, pd.Series)
+    assert_index_equal(result.index, geometry.index)
+
+
+class TestDimensions:
+    def setup_method(self):
+        test_file_path = mm.datasets.get_path("bubenec")
+        self.df_buildings = gpd.read_file(test_file_path, layer="buildings")
+        self.df_streets = gpd.read_file(test_file_path, layer="streets")
+        self.df_tessellation = gpd.read_file(test_file_path, layer="tessellation")
+        self.df_buildings["height"] = np.linspace(10.0, 30.0, 144)
+
+    def test_form_factor(self):
+        expected = {
+            "mean": 5.4486362624193,
+            "sum": 784.60362178837,
+            "min": 4.7712411918919,
+            "max": 9.0604207122634,
+        }
+        r = mm.form_factor(self.df_buildings.geometry, self.df_buildings.height)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_fractal_dimension(self):
+        expected = {
+            "mean": 1.0284229071113,
+            "sum": 148.09289862402,
+            "min": 0.9961153485808,
+            "max": 1.1823500218800869,
+        }
+        r = mm.fractal_dimension(self.df_buildings.geometry)
+        assert_result(r, expected, self.df_buildings)
+
+    def test_facade_ratio(self):
+        expected = {
+            "mean": 5.576164283846954,
+            "sum": 802.9676568739615,
+            "min": 1.693082337025171,
+            "max": 11.314007604595293,
+        }
+        r = mm.facade_ratio(self.df_buildings.geometry)
+        assert_result(r, expected, self.df_buildings)


### PR DESCRIPTION
Completely refactored `shape.py`. This was probably the easiest of them all. 

Performance comparison on data covering whole Prague:

|                              |        old (s) |         new (s) |      comparison |
|:-----------------------------|-----------:|------------:|----------:|
| form_factor                  |  0.0177744 |  0.0144857  | 0.814978  |
| fractal_dimension            |  0.011218  |  0.00919267 | 0.81946   |
| facade_ratio                 |  0.010366  |  0.00798157 | 0.769973  |
| circular_compactness         |  3.75679   |  1.46005    | 0.388644  |
| square_compactness           |  0.0107254 |  0.0082286  | 0.767205  |
| convexity                    |  0.491798  |  0.496109   | 1.00876   |
| courtyard_index              |  0.141855  |  0.141236   | 0.99564   |
| rectangularity               |  0.73733   |  0.738049   | 1.00097   |
| shape_index                  |  1.51152   |  1.50104    | 0.993067  |
| corners                      | 13.3684    |  4.04417    | 0.302518  |
| squareness                   | 13.595     |  5.92453    | 0.435787  |
| equivalent_rectangular_index |  0.872975  |  0.751531   | 0.860885  |
| elongation                   |  0.867414  |  0.735372   | 0.847775  |
| centroid_corner_distance     | 31.7199    | 21.2256     | 0.669158  |
| linearity                    |  0.356025  |  0.0215537  | 0.0605398 |
| compactness_weighted_axis    |  4.12308   |  1.68417    | 0.408473  |

Total speedup, to run all on a single city is 0.54, so we are now nearly twice as fast to compute the same.

@jGaboardi I am aware it is a loooong PR so can split it if you prefer that, but there's a ton of repetition in docstrings and tests so it is not that much. 

I am also quite happy how the code looks compared to the original `shape.py`.

