### PR TITLE
ENH: mean_interbuilding_distance and building_adjacency

### DIFF
--- a/ci/envs/310-latest.yaml
+++ b/ci/envs/310-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - geopandas
   - inequality
-  - libpysal>=4.8.0
+  - libpysal>=4.10.0
   - mapclassify
   - networkx
   - packaging

--- a/ci/envs/310-oldest.yaml
+++ b/ci/envs/310-oldest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - geopandas=0.12
   - inequality
-  - libpysal=4.8.0
+  - libpysal=4.10.0
   - mapclassify
   - networkx=2.7
   - numpy=1.22

--- a/ci/envs/311-latest.yaml
+++ b/ci/envs/311-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.11
   - geopandas
   - inequality
-  - libpysal>=4.8.0
+  - libpysal>=4.10.0
   - mapclassify
   - networkx
   - packaging

--- a/ci/envs/312-dev.yaml
+++ b/ci/envs/312-dev.yaml
@@ -6,7 +6,7 @@ dependencies:
   - dask
   - geopandas
   - inequality
-  - libpysal>=4.8.0
+  - libpysal>=4.10.0
   - networkx
   - osmnx
   - packaging

--- a/ci/envs/312-latest.yaml
+++ b/ci/envs/312-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.12
   - geopandas
   - inequality
-  - libpysal>=4.8.0
+  - libpysal>=4.10.0
   - mapclassify
   - networkx
   - osmnx

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -109,7 +109,7 @@ Dependencies
 Required dependencies:
 
 - `geopandas`_ (>= 0.12.0)
-- `libpysal`_ (>= 4.8.0)
+- `libpysal`_ (>= 4.10.0)
 - `networkx`_
 - `tqdm`_
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - geopandas
   - inequality
   - jupyter
-  - libpysal>=4.8.0
+  - libpysal>=4.10.0
   - mapclassify
   - matplotlib
   - momepy

--- a/momepy/functional/_distribution.py
+++ b/momepy/functional/_distribution.py
@@ -217,10 +217,6 @@ def mean_interbuilding_distance(
 
     for i in range(distance_matrix.shape[0]):
         neighborhood_indices = np.append(neighborhood_matrix[i].indices, i)
-
-        if len(neighborhood_indices) == 0:
-            mean_distances[i] = np.nan
-
         sub_matrix = distance_matrix[neighborhood_indices][:, neighborhood_indices]
         mean_distances[i] = sub_matrix.sum() / sub_matrix.nnz
 

--- a/momepy/functional/_distribution.py
+++ b/momepy/functional/_distribution.py
@@ -227,8 +227,6 @@ def mean_interbuilding_distance(
     return Series(
         mean_distances, index=geometry.index, name="mean_interbuilding_distance"
     )
-    # 35s new
-    # 57s old
 
 
 def building_adjacency(
@@ -272,8 +270,3 @@ def building_adjacency(
     result.name = "building_adjacency"
     result.index.name = None
     return result
-
-    # old: 251 ms ± 14.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
-    # new: 422 ms ± 12.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
-    #  of which 330 ms is assign_self_weight which will be used in other functins so
-    # I'm wondering if it is worth adding a keyword `self_weighted=True` to skip this.

--- a/momepy/functional/_distribution.py
+++ b/momepy/functional/_distribution.py
@@ -261,7 +261,15 @@ def building_adjacency(
     Series
     """
     components = contiguity_graph.component_labels
-    neighborhood_graph = neighborhood_graph.assign_self_weight()
+
+    # check if self-weights are present, otherwise assign them to treat self as part of
+    # the neighborhood
+    has_self_weights = (
+        neighborhood_graph._adjacency.index.get_level_values("focal")
+        == neighborhood_graph._adjacency.index.get_level_values("neighbor")
+    ).sum() == neighborhood_graph.n
+    if not has_self_weights:
+        neighborhood_graph = neighborhood_graph.assign_self_weight()
 
     grouper = components.loc[
         neighborhood_graph._adjacency.index.get_level_values(1)

--- a/momepy/functional/tests/test_distribution.py
+++ b/momepy/functional/tests/test_distribution.py
@@ -64,6 +64,16 @@ class TestDistribution:
         r = mm.neighbor_distance(self.df_buildings, self.graph)
         assert_result(r, expected, self.df_buildings)
 
+    def test_mean_interbuilding_distance(self):
+        expected = {
+            "mean": 16.46438739026651,
+            "sum": 2370.871784198377,
+            "min": 12.279734781239485,
+            "max": 25.45874022563638,
+        }
+        r = mm.mean_interbuilding_distance(self.df_buildings, self.graph)
+        assert_result(r, expected, self.df_buildings)
+
 
 class TestEquality:
     def setup_method(self):
@@ -88,6 +98,13 @@ class TestEquality:
     def test_neighbor_distance(self):
         new = mm.neighbor_distance(self.df_buildings, self.graph)
         old = mm.NeighborDistance(
+            self.df_buildings.reset_index(), self.graph.to_W(), "uID", verbose=False
+        ).series
+        assert_series_equal(new, old, check_names=False, check_index=False)
+
+    def test_mean_interbuilding_distance(self):
+        new = mm.mean_interbuilding_distance(self.df_buildings, self.graph)
+        old = mm.MeanInterbuildingDistance(
             self.df_buildings.reset_index(), self.graph.to_W(), "uID", verbose=False
         ).series
         assert_series_equal(new, old, check_names=False, check_index=False)

--- a/momepy/functional/tests/test_distribution.py
+++ b/momepy/functional/tests/test_distribution.py
@@ -13,6 +13,7 @@ class TestDistribution:
         self.df_buildings = gpd.read_file(test_file_path, layer="buildings")
         self.df_streets = gpd.read_file(test_file_path, layer="streets")
         self.graph = Graph.build_knn(self.df_buildings.centroid, k=5)
+        self.contiguity = Graph.build_contiguity(self.df_buildings)
 
     def test_orientation(self):
         expected = {
@@ -74,6 +75,16 @@ class TestDistribution:
         r = mm.mean_interbuilding_distance(self.df_buildings, self.graph)
         assert_result(r, expected, self.df_buildings)
 
+    def test_building_adjacency(self):
+        expected = {
+            "mean": 0.4402777777777778,
+            "sum": 63.4,
+            "min": 0.2,
+            "max": 1,
+        }
+        r = mm.building_adjacency(self.graph, self.contiguity.assign_self_weight())
+        assert_result(r, expected, self.df_buildings, exact=False)
+
 
 class TestEquality:
     def setup_method(self):
@@ -83,6 +94,7 @@ class TestEquality:
         )
         self.graph = Graph.build_knn(self.df_buildings.centroid, k=5)
         self.df_buildings["orientation"] = mm.orientation(self.df_buildings)
+        self.contiguity = Graph.build_contiguity(self.df_buildings)
 
     def test_alignment(self):
         new = mm.alignment(self.df_buildings["orientation"], self.graph)
@@ -105,6 +117,13 @@ class TestEquality:
     def test_mean_interbuilding_distance(self):
         new = mm.mean_interbuilding_distance(self.df_buildings, self.graph)
         old = mm.MeanInterbuildingDistance(
+            self.df_buildings.reset_index(), self.graph.to_W(), "uID", verbose=False
+        ).series
+        assert_series_equal(new, old, check_names=False, check_index=False)
+
+    def test_building_adjacency(self):
+        new = mm.building_adjacency(self.graph.assign_self_weight(), self.contiguity)
+        old = mm.BuildingAdjacency(
             self.df_buildings.reset_index(), self.graph.to_W(), "uID", verbose=False
         ).series
         assert_series_equal(new, old, check_names=False, check_index=False)

--- a/momepy/functional/tests/test_shape.py
+++ b/momepy/functional/tests/test_shape.py
@@ -10,12 +10,12 @@ import momepy as mm
 GPD_013 = Version(gpd.__version__) >= Version("0.13")
 
 
-def assert_result(result, expected, geometry):
+def assert_result(result, expected, geometry, **kwargs):
     """Check the expected values and types of the result."""
     for key, value in expected.items():
         assert getattr(result, key)() == pytest.approx(value)
     assert isinstance(result, pd.Series)
-    assert_index_equal(result.index, geometry.index)
+    assert_index_equal(result.index, geometry.index, **kwargs)
 
 
 class TestShape:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "geopandas>=0.12.0",
-    "libpysal>=4.8.0",
+    "libpysal>=4.10.0",
     "networkx>=2.7",
     "packaging",
     "pandas!=1.5.0",


### PR DESCRIPTION
Gosh I spent way too much time on this...

mean_interbuilding_distance:

```
35s new
57s old
```

Given my first attempt took 5mins, I call this a victory. 

building_adjacency:

```
 old: 251 ms ± 14.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 new: 422 ms ± 12.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

of which 330 ms is `assign_self_weight` which will be used in other functions so I'm wondering if it is worth adding a keyword `self_weighted=True` to skip this. In practice it is nearly negligible difference though...

These two functions also quite significantly change the API compared to the original. @jGaboardi can you give it a thought whether it makes sense in this way? I think it does and it is more flexible than before but it is different.