### PR TITLE
ENH: add neighbors

### DIFF
--- a/momepy/functional/_distribution.py
+++ b/momepy/functional/_distribution.py
@@ -313,8 +313,3 @@ def neighbors(
 
     r.name = "neighbors"
     return r
-
-    # CPU times: user 49.5 ms, sys: 121 ms, total: 170 ms
-    # Wall time: 179 ms
-    # 25.7 ms ± 190 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
-    # 549 ms ± 2.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

--- a/momepy/functional/_distribution.py
+++ b/momepy/functional/_distribution.py
@@ -15,6 +15,7 @@ __all__ = [
     "neighbor_distance",
     "mean_interbuilding_distance",
     "building_adjacency",
+    "neighbors",
 ]
 
 GPD_GE_013 = Version(gpd.__version__) >= Version("0.13.0")
@@ -274,3 +275,46 @@ def building_adjacency(
     result.name = "building_adjacency"
     result.index.name = None
     return result
+
+
+def neighbors(
+    geometry: GeoDataFrame | GeoSeries, graph: Graph, weighted=False
+) -> pd.Series:
+    """Calculate the number of neighbours captured by ``graph``.
+
+    If ``weighted=True``, the number of neighbours will be divided by the perimeter of
+    the object to return a relative value (neighbors per meter).
+
+    Adapted from :cite:`hermosilla2012`.
+
+    Notes
+    -----
+    The index of ``geometry`` must match the index along which the ``graph`` is
+    built.
+
+    Parameters
+    ----------
+    gdf : gpd.GeoDataFrame
+        GeoDataFrame containing geometries to analyse.
+    graph : libpysal.graph.Graph
+        Graph representing spatial relationships between elements.
+    weighted : bool
+        If True, the number of neighbours will be divided by the perimeter of the object
+        to return a relative value (neighbors per meter).
+
+    Returns
+    -------
+    pd.Series
+    """
+    if weighted:
+        r = graph.cardinalities / geometry.length
+    else:
+        r = graph.cardinalities
+
+    r.name = "neighbors"
+    return r
+
+    # CPU times: user 49.5 ms, sys: 121 ms, total: 170 ms
+    # Wall time: 179 ms
+    # 25.7 ms ± 190 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+    # 549 ms ± 2.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ momepy = ["datasets/bubenec.gpkg", "datasets/tests.gpkg"]
 [tool.ruff]
 line-length = 88
 select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
-ignore = ["B006", "F403"]
+ignore = ["B006", "F403", "SIM108"]
 exclude = ["momepy/tests/*", "docs/*", "benchmarks/*"]
 
 [tool.coverage.run]


### PR DESCRIPTION
Easy one this time. Hard to time, as `cardinalities` are cached.

```
# first run (weighted)
    # CPU times: user 49.5 ms, sys: 121 ms, total: 170 ms
    # Wall time: 179 ms
# timeit
    # 25.7 ms ± 190 µs per loop (mean ± std. dev. of 7 runs, 10 loops each) - new
    # 549 ms ± 2.07 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) - old
```

 Faster esp. if other function before called cardinalities.