### PR TITLE
REF: speed-up describe using numba

### DIFF
--- a/momepy/functional/_diversity.py
+++ b/momepy/functional/_diversity.py
@@ -2,7 +2,6 @@ import numpy as np
 from libpysal.graph import Graph
 from numpy.typing import NDArray
 from pandas import DataFrame, Series
-from scipy import stats
 
 try:
     from numba import njit
@@ -97,7 +96,7 @@ def describe(
     if q is None:
         stat_ = grouper.agg(["mean", "median", "std", "min", "max", "sum"])
         if include_mode:
-            stat_["mode"] = grouper.agg(lambda x: stats.mode(x, keepdims=False)[0])
+            stat_["mode"] = grouper.agg(lambda x: _mode(x.values))
     else:
         agg = grouper.agg(lambda x: _describe(x.values, q=q, include_mode=include_mode))
         stat_ = DataFrame(zip(*agg, strict=True)).T


### PR DESCRIPTION
Follow-up on #570 

Had to reimplement `mode` to actually compile based on https://github.com/numba/numba/pull/2959#issuecomment-741715733. 

Timings compared to #570 

```
only quantiles
# new 2.23 s ± 65.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# old 7.96 s ± 59.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

no quantiles, mode
# new 1.25 s ± 7.76 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# old 15 s ± 488 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

quantiles and mode
# new 2.48 s ± 42.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# old  23 s ± 562 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

How would you set the CI envs to test numba and fallback options? I am not a big fan of having everything twice. Would 1 env without numba be enough in your experience?