### PR TITLE
MAINT: compatibility, warning cleanup, test lint

### DIFF
--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -61,7 +61,7 @@ class COINS:
     -----
     The LineStrings of the ``edge_gdf`` are not expected to overlap. If you are creating
     it using OSMnx, don't forget to cast the graph to undirected using
-    ``osmnx.get_undirected(G)`` prior converting it to a GeoDataFrame.
+    ``osmnx.convert.to_undirected(G)`` prior converting it to a GeoDataFrame.
     """
 
     def __init__(self, edge_gdf, angle_threshold=0):

--- a/momepy/functional/_elements.py
+++ b/momepy/functional/_elements.py
@@ -10,7 +10,7 @@ from libpysal.cg import voronoi_frames
 from packaging.version import Version
 
 GPD_GE_013 = Version(gpd.__version__) >= Version("0.13.0")
-GPD_GE_10 = Version(gpd.__version__) >= Version("1.0.0")
+GPD_GE_10 = Version(gpd.__version__) >= Version("1.0dev")
 
 __all__ = [
     "morphological_tessellation",

--- a/momepy/functional/tests/test_elements.py
+++ b/momepy/functional/tests/test_elements.py
@@ -21,7 +21,8 @@ class TestElements:
         self.df_streets = gpd.read_file(test_file_path, layer="streets")
         self.limit = mm.buffered_limit(self.df_buildings, 50)
         self.enclosures = mm.enclosures(
-            self.df_streets, gpd.GeoSeries([self.limit.exterior])
+            self.df_streets,
+            gpd.GeoSeries([self.limit.exterior], crs=self.df_streets.crs),
         )
 
     def test_morphological_tessellation(self):
@@ -77,6 +78,7 @@ class TestElements:
                         affinity.rotate(df.geometry.iloc[0], 12),
                     ],
                     index=[144, 145, 146],
+                    crs=df.crs,
                 ),
             ]
         )
@@ -155,6 +157,7 @@ class TestElements:
                         Polygon([(x, y), (x, y + 1), (x + 1, y)]),
                     ],
                     index=[144],
+                    crs=df.crs,
                 ),
             ]
         )

--- a/momepy/tests/test_dimension.py
+++ b/momepy/tests/test_dimension.py
@@ -219,7 +219,7 @@ class TestDimensions:
 
         # avoid infinity
         blg = gpd.GeoDataFrame(
-            dict(height=[2, 5]),
+            {"height": [2, 5]},
             geometry=[
                 Point(0, 0).buffer(10, cap_style=3),
                 Point(30, 0).buffer(10, cap_style=3),

--- a/momepy/tests/test_distribution.py
+++ b/momepy/tests/test_distribution.py
@@ -2,8 +2,8 @@ import geopandas as gpd
 import numpy as np
 import pytest
 import shapely
-from packaging.version import Version
 from libpysal.weights import Queen
+from packaging.version import Version
 
 import momepy as mm
 
@@ -173,7 +173,9 @@ class TestDistribution:
         assert self.df_streets["dev"].mean() == pytest.approx(check)
 
     def test_BuildingAdjacency(self):
-        sw = Queen.from_dataframe(self.df_buildings, ids="uID", silence_warnings=True)
+        sw = Queen.from_dataframe(
+            self.df_buildings, ids="uID", silence_warnings=True, use_index=False
+        )
         swh = mm.sw_high(k=3, gdf=self.df_tessellation, ids="uID")
         self.df_buildings["adj_sw"] = mm.BuildingAdjacency(
             self.df_buildings,

--- a/momepy/tests/test_diversity.py
+++ b/momepy/tests/test_diversity.py
@@ -114,7 +114,7 @@ class TestDiversity:
             self.df_tessellation.area - self.df_tessellation.area.mean()
         )
         with pytest.raises(ValueError):
-            mm.Gini(self.df_tessellation, "negative", self.sw, "uID").series
+            mm.Gini(self.df_tessellation, "negative", self.sw, "uID").series  # noqa: B018
         assert (
             mm.Gini(self.df_tessellation, "area", self.sw_drop, "uID")
             .series.isna()
@@ -220,7 +220,9 @@ class TestDiversity:
 
         _data = {"uID": [9999], "area": 1.0}
         _pgon = [Polygon(((0, 0), (0, 1), (1, 1), (1, 0)))]
-        _gdf = gpd.GeoDataFrame(_data, index=[9999], geometry=_pgon)
+        _gdf = gpd.GeoDataFrame(
+            _data, index=[9999], geometry=_pgon, crs=self.df_tessellation.crs
+        )
 
         perc = mm.Percentiles(
             pd.concat([self.df_tessellation, _gdf]),

--- a/momepy/tests/test_elements.py
+++ b/momepy/tests/test_elements.py
@@ -15,6 +15,7 @@ import momepy as mm
 
 GPD_GE_013 = Version(gpd.__version__) >= Version("0.13.0")
 
+
 class TestElements:
     def setup_method(self):
         test_file_path = mm.datasets.get_path("bubenec")
@@ -24,7 +25,8 @@ class TestElements:
         self.df_streets["nID"] = range(len(self.df_streets))
         self.limit = mm.buffered_limit(self.df_buildings, 50)
         self.enclosures = mm.enclosures(
-            self.df_streets, gpd.GeoSeries([self.limit.exterior])
+            self.df_streets,
+            gpd.GeoSeries([self.limit.exterior], crs=self.df_streets.crs),
         )
 
     def test_Tessellation(self):
@@ -89,17 +91,18 @@ class TestElements:
                         affinity.rotate(df.geometry.iloc[0], 12),
                     ],
                     index=[144, 145, 146],
+                    crs=df.crs,
                 ),
             ]
         )
 
-        with pytest.warns(
-            UserWarning, match="Tessellation does not fully match buildings."
-        ):
-            mm.Tessellation(df, "uID", self.limit)
-
-        with pytest.warns(
-            UserWarning, match="Tessellation contains MultiPolygon elements."
+        with (
+            pytest.warns(
+                UserWarning, match="Tessellation does not fully match buildings."
+            ),
+            pytest.warns(
+                UserWarning, match="Tessellation contains MultiPolygon elements."
+            ),
         ):
             tess = mm.Tessellation(df, "uID", self.limit)
             assert tess.collapsed == {145}
@@ -148,10 +151,17 @@ class TestElements:
         assert not blocks.buildings_id.isna().any()
         assert len(blocks.blocks) == 9
         if GPD_GE_013:
-            assert len(blocks.blocks.sindex.query(blocks.blocks.geometry, "overlaps")[0]) == 0
+            assert (
+                len(blocks.blocks.sindex.query(blocks.blocks.geometry, "overlaps")[0])
+                == 0
+            )
         else:
             assert (
-                len(blocks.blocks.sindex.query_bulk(blocks.blocks.geometry, "overlaps")[0])
+                len(
+                    blocks.blocks.sindex.query_bulk(blocks.blocks.geometry, "overlaps")[
+                        0
+                    ]
+                )
                 == 0
             )
 
@@ -186,8 +196,10 @@ class TestElements:
         nx = mm.gdf_to_nx(self.df_streets)
         nodes, edges = mm.nx_to_gdf(nx)
 
-        convex_hull = edges.unary_union.convex_hull
-        enclosures = mm.enclosures(edges, limit=gpd.GeoSeries([convex_hull]))
+        convex_hull = edges.dissolve().convex_hull.item()
+        enclosures = mm.enclosures(
+            edges, limit=gpd.GeoSeries([convex_hull], crs=edges.crs)
+        )
         enclosed_tess = mm.Tessellation(
             self.df_buildings, unique_id="uID", enclosures=enclosures
         ).tessellation
@@ -214,32 +226,46 @@ class TestElements:
         assert len(limited) == 20
         assert isinstance(limited, gpd.GeoDataFrame)
 
-        limited2 = mm.enclosures(self.df_streets, gpd.GeoSeries([self.limit]))
+        limited2 = mm.enclosures(
+            self.df_streets, gpd.GeoSeries([self.limit], crs=self.df_streets.crs)
+        )
         assert len(limited2) == 20
         assert isinstance(limited2, gpd.GeoDataFrame)
 
         b = self.limit.bounds
-        additional_barrier = gpd.GeoSeries([LineString([(b[0], b[1]), (b[2], b[3])])])
+        additional_barrier = gpd.GeoSeries(
+            [LineString([(b[0], b[1]), (b[2], b[3])])], crs=self.df_streets.crs
+        )
 
         additional = mm.enclosures(
-            self.df_streets, gpd.GeoSeries([self.limit]), [additional_barrier]
+            self.df_streets,
+            gpd.GeoSeries([self.limit], crs=self.df_streets.crs),
+            [additional_barrier],
         )
         assert len(additional) == 28
         assert isinstance(additional, gpd.GeoDataFrame)
 
         with pytest.raises(TypeError, match="`additional_barriers` expects a list"):
             additional = mm.enclosures(
-                self.df_streets, gpd.GeoSeries([self.limit]), additional_barrier
+                self.df_streets,
+                gpd.GeoSeries([self.limit], crs=self.df_streets.crs),
+                additional_barrier,
             )
 
         # test clip
-        limit = self.df_streets.unary_union.convex_hull.buffer(-100)
-        encl = mm.enclosures(self.df_streets, limit=gpd.GeoSeries([limit]), clip=True)
+        limit = self.df_streets.dissolve().convex_hull.buffer(-100).item()
+        encl = mm.enclosures(
+            self.df_streets,
+            limit=gpd.GeoSeries([limit], crs=self.df_streets.crs),
+            clip=True,
+        )
         assert len(encl) == 18
 
     def test_get_network_ratio(self):
-        convex_hull = self.df_streets.unary_union.convex_hull
-        enclosures = mm.enclosures(self.df_streets, limit=gpd.GeoSeries([convex_hull]))
+        convex_hull = self.df_streets.dissolve().convex_hull.item()
+        enclosures = mm.enclosures(
+            self.df_streets, limit=gpd.GeoSeries([convex_hull], crs=self.df_streets.crs)
+        )
         enclosed_tess = mm.Tessellation(
             self.df_buildings, unique_id="uID", enclosures=enclosures
         ).tessellation

--- a/momepy/tests/test_graph.py
+++ b/momepy/tests/test_graph.py
@@ -1,7 +1,5 @@
 import geopandas as gpd
-import networkx as nx
 import pytest
-from packaging.version import Version
 
 import momepy as mm
 
@@ -149,9 +147,9 @@ class TestGraph:
         net2 = mm.straightness_centrality(
             self.network, normalized=False, name="nonnorm"
         )
-        G = self.network.copy()
-        G.add_node(1)
-        net3 = mm.straightness_centrality(G)
+        g = self.network.copy()
+        g.add_node(1)
+        net3 = mm.straightness_centrality(g)
         check = 0.8574045143712158
         nonnorm = 0.8574045143712158
         assert (

--- a/momepy/tests/test_intensity.py
+++ b/momepy/tests/test_intensity.py
@@ -2,8 +2,8 @@ import geopandas as gpd
 import numpy as np
 import pytest
 from libpysal.weights import Queen
-from shapely.geometry import Point
 from pandas.testing import assert_series_equal
+from shapely.geometry import Point
 
 import momepy as mm
 
@@ -103,11 +103,13 @@ class TestIntensity:
         with pytest.raises(
             TypeError, match="Geometry type does not support weighting."
         ):
-            mm.Count(point_gdf, self.blocks, "nID", "bID", weighted=True).series
+            mm.Count(point_gdf, self.blocks, "nID", "bID", weighted=True).series  # noqa: B018
 
     def test_Courtyards(self):
         courtyards = mm.Courtyards(self.df_buildings).series
-        sw = Queen.from_dataframe(self.df_buildings, silence_warnings=True)
+        sw = Queen.from_dataframe(
+            self.df_buildings, silence_warnings=True, use_index=False
+        )
         courtyards_wm = mm.Courtyards(self.df_buildings, sw).series
         check = 0.6805555555555556
         assert courtyards.mean() == check

--- a/momepy/tests/test_preprocess.py
+++ b/momepy/tests/test_preprocess.py
@@ -167,7 +167,7 @@ class TestPreprocessing:
     @pytest.mark.parametrize("method", ["spider", "euclidean", "extend"])
     def test_consolidate_intersections(self, method):
         ox = pytest.importorskip("osmnx")
-        graph = ox.get_undirected(ox.load_graphml(self.test_file_path3))
+        graph = ox.convert.to_undirected(ox.load_graphml(self.test_file_path3))
 
         tol = 30
         graph_simplified = mm.consolidate_intersections(
@@ -186,7 +186,7 @@ class TestPreprocessing:
 
     def test_consolidate_intersections_unsupported(self):
         ox = pytest.importorskip("osmnx")
-        graph = ox.get_undirected(ox.load_graphml(self.test_file_path3))
+        graph = ox.convert.to_undirected(ox.load_graphml(self.test_file_path3))
         with pytest.raises(ValueError, match="Simplification 'banana' not recognized"):
             mm.consolidate_intersections(
                 graph,

--- a/momepy/tests/test_preprocess.py
+++ b/momepy/tests/test_preprocess.py
@@ -2,7 +2,6 @@ import geopandas as gpd
 import numpy as np
 import pytest
 from geopandas.testing import assert_geodataframe_equal
-from packaging.version import Version
 from shapely import affinity
 from shapely.geometry import LineString, MultiPoint, Point, Polygon
 from shapely.ops import polygonize
@@ -21,7 +20,7 @@ class TestPreprocessing:
         self.df_streets_rabs = gpd.read_file(test_file_path2, layer="test_rabs")
         plgns = polygonize(self.df_streets_rabs.geometry)
         self.df_rab_polys = gpd.GeoDataFrame(
-            geometry=[g for g in plgns], crs=self.df_streets_rabs.crs
+            geometry=list(plgns), crs=self.df_streets_rabs.crs
         )
         self.test_file_path3 = mm.datasets.get_path("nyc_graph", extension="graphml")
 
@@ -195,6 +194,7 @@ class TestPreprocessing:
                 rebuild_graph=True,
                 rebuild_edges_method="banana",
             )
+
 
 def test_FaceArtifacts():
     pytest.importorskip("esda")

--- a/momepy/tests/test_preprocess.py
+++ b/momepy/tests/test_preprocess.py
@@ -214,7 +214,7 @@ def test_FaceArtifacts():
     )
     streets_graph = osmnx.projection.project_graph(streets_graph)
     gdf = osmnx.graph_to_gdfs(
-        osmnx.get_undirected(streets_graph),
+        osmnx.convert.to_undirected(streets_graph),
         nodes=False,
         edges=True,
         node_geometry=False,

--- a/momepy/tests/test_shape.py
+++ b/momepy/tests/test_shape.py
@@ -3,7 +3,7 @@ import math
 import geopandas as gpd
 import numpy as np
 import pytest
-from shapely.geometry import MultiLineString, Point, Polygon, MultiPolygon
+from shapely.geometry import MultiLineString, MultiPolygon, Point, Polygon
 
 import momepy as mm
 from momepy.shape import _circle_area

--- a/momepy/tests/test_utils.py
+++ b/momepy/tests/test_utils.py
@@ -2,7 +2,6 @@ import geopandas as gpd
 import networkx
 import numpy as np
 import pytest
-from packaging.version import Version
 from shapely.geometry import LineString, Point
 
 import momepy as mm
@@ -134,6 +133,7 @@ class TestUtils:
             "x": 1603585.6402153103,
             "y": 6464428.773867372,
         }
+
     def test_nx_to_gdf(self):
         nx = mm.gdf_to_nx(self.df_streets)
         nodes, edges, W = mm.nx_to_gdf(nx, spatial_weights=True)
@@ -162,14 +162,14 @@ class TestUtils:
         # check graph without attributes
         G = networkx.MultiGraph()
         key = 0
-        for index, row in self.df_streets.iterrows():
+        for _index, row in self.df_streets.iterrows():
             first = row.geometry.coords[0]
             last = row.geometry.coords[-1]
 
             data = [row[f] for f in list(self.df_streets.columns)]
-            attributes = dict(zip(list(self.df_streets.columns), data))
+            attributes = dict(zip(list(self.df_streets.columns), data, strict=False))
             G.add_edge(first, last, key=key, **attributes)
-            key += 1
+            key += 1  # noqa: SIM113
 
         with pytest.warns(UserWarning, match="Approach is not set"):
             nodes, edges = mm.nx_to_gdf(G)
@@ -197,7 +197,16 @@ class TestUtils:
 
     def test_limit_range(self):
         assert list(mm.limit_range(np.arange(10), rng=(25, 75))) == [2, 3, 4, 5, 6, 7]
-        assert list(mm.limit_range(np.arange(10), rng=(10, 90))) == [1, 2, 3, 4, 5, 6, 7, 8]
+        assert list(mm.limit_range(np.arange(10), rng=(10, 90))) == [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+        ]
         assert list(mm.limit_range(np.array([0, 1]), rng=(25, 75))) == [0, 1]
         assert list(
             mm.limit_range(np.array([0, 1, 2, 3, 4, np.nan]), rng=(25, 75))

--- a/momepy/tests/test_weights.py
+++ b/momepy/tests/test_weights.py
@@ -13,7 +13,9 @@ class TestWeights:
         self.df_tessellation["area"] = mm.Area(self.df_tessellation).series
 
     def test_sw_high(self):
-        first_order = libpysal.weights.Queen.from_dataframe(self.df_tessellation)
+        first_order = libpysal.weights.Queen.from_dataframe(
+            self.df_tessellation, use_index=False
+        )
         from_sw = mm.sw_high(2, gdf=None, weights=first_order)
         from_df = mm.sw_high(2, gdf=self.df_tessellation)
         rook = mm.sw_high(2, gdf=self.df_tessellation, contiguity="rook")
@@ -41,10 +43,10 @@ class TestWeights:
         db_ids = mm.DistanceBand(self.df_buildings, 100, ids="uID")
 
         for k in range(len(self.df_buildings)):
-            assert k in db.neighbors.keys()
+            assert k in db.neighbors.keys()  # noqa: SIM118
             assert sorted(lp.neighbors[k]) == sorted(db.neighbors[k])
         for k in self.df_buildings.uID:
-            assert k in db_ids.neighbors.keys()
+            assert k in db_ids.neighbors.keys()  # noqa: SIM118
             assert sorted(lp_ids.neighbors[k]) == sorted(db_ids.neighbors[k])
 
         db_cent_false = mm.DistanceBand(self.df_buildings, 100, centroid=False)

--- a/momepy/utils.py
+++ b/momepy/utils.py
@@ -96,7 +96,9 @@ def _generate_dual(graph, gdf_network, fields, angles, multigraph, angle):
     graph.graph["approach"] = "dual"
     key = 0
 
-    sw = libpysal.weights.Queen.from_dataframe(gdf_network, silence_warnings=True)
+    sw = libpysal.weights.Queen.from_dataframe(
+        gdf_network, silence_warnings=True, use_index=False
+    )
     cent = gdf_network.geometry.centroid
     gdf_network["temp_x_coords"] = cent.x
     gdf_network["temp_y_coords"] = cent.y

--- a/momepy/weights.py
+++ b/momepy/weights.py
@@ -122,11 +122,11 @@ def sw_high(k, gdf=None, weights=None, ids=None, contiguity="queen", silent=True
     elif gdf is not None:
         if contiguity == "queen":
             first_order = libpysal.weights.Queen.from_dataframe(
-                gdf, ids=ids, silence_warnings=silent
+                gdf, ids=ids, silence_warnings=silent, use_index=False
             )
         elif contiguity == "rook":
             first_order = libpysal.weights.Rook.from_dataframe(
-                gdf, ids=ids, silence_warnings=silent
+                gdf, ids=ids, silence_warnings=silent, use_index=False
             )
         else:
             raise ValueError(f"{contiguity} is not supported. Use 'queen' or 'rook'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,10 @@ momepy = ["datasets/bubenec.gpkg", "datasets/tests.gpkg"]
 line-length = 88
 lint.select = ["E", "F", "W", "I", "UP", "N", "B", "A", "C4", "SIM", "ARG"]
 lint.ignore = ["B006", "F403", "SIM108"]
-exclude = ["momepy/tests/*", "docs/*", "benchmarks/*"]
+exclude = ["docs/*", "benchmarks/*"]
+
+[tool.ruff.lint.per-file-ignores]
+"momepy/tests/*" = ["N802", "N806"]
 
 [tool.coverage.run]
 source = ['momepy']


### PR DESCRIPTION
I wanted to primarily cleanup warnings from our CI. So some changes related to that, some changes related to compatibility (FutureWarning removal), plus linting of tests which was for some reason disabled.