### PR TITLE
ENH: adaptive buffer as a tessellation limit

### DIFF
--- a/momepy/elements.py
+++ b/momepy/elements.py
@@ -16,7 +16,6 @@ from shapely.ops import polygonize
 from tqdm.auto import tqdm
 
 __all__ = [
-    "buffered_limit",
     "Tessellation",
     "Blocks",
     "get_network_id",
@@ -27,35 +26,6 @@ __all__ = [
 
 GPD_GE_013 = Version(gpd.__version__) >= Version("0.13.0")
 GPD_GE_10 = Version(gpd.__version__) >= Version("1.0dev")
-
-
-def buffered_limit(gdf, buffer=100):
-    """
-    Define limit for :class:`momepy.Tessellation` as a buffer around buildings.
-
-    See :cite:`fleischmann2020` for details.
-
-    Parameters
-    ----------
-    gdf : GeoDataFrame
-        A GeoDataFrame containing building footprints.
-    buffer : float
-        A buffer around buildings limiting the extend of tessellation.
-
-    Returns
-    -------
-    MultiPolygon
-        A MultiPolygon or Polygon defining the study area.
-
-    Examples
-    --------
-    >>> limit = mm.buffered_limit(buildings_df)
-    >>> type(limit)
-    shapely.geometry.polygon.Polygon
-    """
-    return (
-        gdf.buffer(buffer).union_all() if GPD_GE_10 else gdf.buffer(buffer).unary_union
-    )
 
 
 class Tessellation:

--- a/momepy/functional/_elements.py
+++ b/momepy/functional/_elements.py
@@ -352,6 +352,7 @@ def buffered_limit(
     buffer: float | str = 100,
     min_buffer: float = 0,
     max_buffer: float = 100,
+    **kwargs,
 ) -> shapely.Geometry:
     """
     Define limit for tessellation as a buffer around buildings.
@@ -376,6 +377,8 @@ def buffered_limit(
         The minimum adaptive buffer distance. By default 0.
     max_buffer : float, optional
         The maximum adaptive buffer distance. By default 100.
+    **kwargs
+        Keyword arguments passed to :meth:`geopandas.GeoSeries.buffer`.
 
     Returns
     -------
@@ -397,5 +400,7 @@ def buffered_limit(
     else:
         raise ValueError("buffer must be either 'adaptive' or a number")
     return (
-        gdf.buffer(buffer).union_all() if GPD_GE_10 else gdf.buffer(buffer).unary_union
+        gdf.buffer(buffer, **kwargs).union_all()
+        if GPD_GE_10
+        else gdf.buffer(buffer, **kwargs).unary_union
     )

--- a/momepy/functional/tests/test_elements.py
+++ b/momepy/functional/tests/test_elements.py
@@ -215,17 +215,17 @@ class TestElements:
     def test_buffered_limit_adaptive(self):
         limit = mm.buffered_limit(self.df_buildings, "adaptive")
         assert limit.geom_type == "Polygon"
-        assert pytest.approx(limit.area) == 346666.41098618
+        assert pytest.approx(limit.area) == 355819.18954170
 
         limit = mm.buffered_limit(self.df_buildings, "adaptive", max_buffer=30)
         assert limit.geom_type == "Polygon"
-        assert pytest.approx(limit.area) == 304978.77564085
+        assert pytest.approx(limit.area) == 304200.301833294
 
         limit = mm.buffered_limit(
             self.df_buildings, "adaptive", min_buffer=30, max_buffer=300
         )
         assert limit.geom_type == "Polygon"
-        assert pytest.approx(limit.area) == 348502.38744819
+        assert pytest.approx(limit.area) == 357671.831894244
 
     @pytest.mark.skipif(LPS_GE_411, reason="libpysal>=4.11 required")
     def test_buffered_limit_adaptive_error(self):


### PR DESCRIPTION
Making use of Gabriel graph to determine the buffer of each building when defining the study area.

See this [notebook](https://github.com/uscuni/urban_taxonomy/blob/main/code/adaptive_buffer.ipynb) for explanation.

It requires libpysal main to properly work...