### PR TITLE
DEP: bump libpysal minimum to 4.11

### DIFF
--- a/ci/envs/310-latest.yaml
+++ b/ci/envs/310-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - geopandas
   - inequality
-  - libpysal>=4.10.0
+  - libpysal>=4.11.0
   - mapclassify
   - networkx
   - packaging

--- a/ci/envs/310-oldest.yaml
+++ b/ci/envs/310-oldest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.10
   - geopandas=0.12
   - inequality
-  - libpysal=4.10.0
+  - libpysal=4.11.0
   - mapclassify
   - networkx=2.7
   - numpy=1.22

--- a/ci/envs/311-latest.yaml
+++ b/ci/envs/311-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.11
   - geopandas
   - inequality
-  - libpysal>=4.10.0
+  - libpysal>=4.11.0
   - mapclassify
   - networkx
   - packaging

--- a/ci/envs/312-dev.yaml
+++ b/ci/envs/312-dev.yaml
@@ -6,7 +6,7 @@ dependencies:
   - dask
   - geopandas
   - inequality
-  - libpysal>=4.10.0
+  - libpysal>=4.11.0
   - networkx
   - osmnx
   - packaging

--- a/ci/envs/312-latest.yaml
+++ b/ci/envs/312-latest.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.12
   - geopandas
   - inequality
-  - libpysal>=4.10.0
+  - libpysal>=4.11.0
   - mapclassify
   - networkx
   - osmnx

--- a/ci/envs/312-min.yaml
+++ b/ci/envs/312-min.yaml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.12
   - geopandas
   - inequality
-  - libpysal>=4.10.0
+  - libpysal>=4.11.0
   - mapclassify
   - networkx
   - osmnx

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -109,7 +109,7 @@ Dependencies
 Required dependencies:
 
 - `geopandas`_ (>= 0.12.0)
-- `libpysal`_ (>= 4.10.0)
+- `libpysal`_ (>= 4.11.0)
 - `networkx`_
 - `tqdm`_
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - geopandas
   - inequality
   - jupyter
-  - libpysal>=4.10.0
+  - libpysal>=4.11.0
   - mapclassify
   - matplotlib
   - networkx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "geopandas>=0.12.0",
-    "libpysal>=4.10.0",
+    "libpysal>=4.11.0",
     "networkx>=2.7",
     "packaging",
     "pandas!=1.5.0",


### PR DESCRIPTION
We need to depend heavily on `Graph.describe()`, so better pin 4.11 than raise a ton of ImportErrors. SPEC0 is imho irrelevant within the fed.