### PR TITLE
DOC: note on a precision issue in enclosed_tessellation

### DIFF
--- a/momepy/functional/_elements.py
+++ b/momepy/functional/_elements.py
@@ -159,7 +159,7 @@ def enclosed_tessellation(
     coverage. To build a contiguity graph, use fuzzy contiguity builder with a small
     buffer, e.g.::
 
-        from libpysal imoprt graph
+        from libpysal import graph
 
         graph.Graph.build_fuzzy_contiguity(tessellation, buffer=1e-8)
 

--- a/momepy/functional/_elements.py
+++ b/momepy/functional/_elements.py
@@ -43,15 +43,15 @@ def morphological_tessellation(
     and there are three particular patterns causing issues:
 
     1. Features will collapse into empty polygon - these
-        do not have tessellation cell in the end.
+       do not have tessellation cell in the end.
     2. Features will split into MultiPolygons - in some cases,
-        features with narrow links between parts split into two
-        during 'shrinking'. In most cases that is not an issue
-        and the resulting tessellation is correct anyway, but
-        sometimes this results in a cell being a MultiPolygon,
-        which is not correct.
+       features with narrow links between parts split into two
+       during 'shrinking'. In most cases that is not an issue
+       and the resulting tessellation is correct anyway, but
+       sometimes this results in a cell being a MultiPolygon,
+       which is not correct.
     3. Overlapping features - features which overlap even
-        after 'shrinking' cause invalid tessellation geometry.
+       after 'shrinking' cause invalid tessellation geometry.
 
     All three types can be tested using :class:`momepy.CheckTessellationInput`.
 
@@ -115,14 +115,14 @@ def enclosed_tessellation(
     particular patterns causing issues:
 
     1. Features will collapse into empty polygon - these
-        do not have tessellation cell in the end.
+       do not have tessellation cell in the end.
     2. Features will split into MultiPolygons - in some cases,
-        features with narrow links between parts split into two during 'shrinking'.
-        In most cases that is not an issue and the resulting tessellation is correct
-        anyway, but sometimes this results in a cell being a MultiPolygon, which is
-        not correct.
+       features with narrow links between parts split into two during 'shrinking'.
+       In most cases that is not an issue and the resulting tessellation is correct
+       anyway, but sometimes this results in a cell being a MultiPolygon, which is
+       not correct.
     3. Overlapping features - features which overlap even
-        after 'shrinking' cause invalid tessellation geometry.
+       after 'shrinking' cause invalid tessellation geometry.
 
     All three types can be tested using :class:`momepy.CheckTessellationInput`.
 
@@ -151,6 +151,17 @@ def enclosed_tessellation(
     n_jobs : int, optional
         The number of jobs to run in parallel. -1 means using all available cores.
         By default -1
+
+    Warnings
+    --------
+    Due to the floating point precision issues in clipping the tessellation cells to the
+    extent of their parental enclosures, the result does not form a precise polygonal
+    coverage. To build a contiguity graph, use fuzzy contiguity builder with a small
+    buffer, e.g.::
+
+        from libpysal imoprt graph
+
+        graph.Graph.build_fuzzy_contiguity(tessellation, buffer=1e-8)
 
     Returns
     -------

--- a/momepy/functional/_elements.py
+++ b/momepy/functional/_elements.py
@@ -161,7 +161,7 @@ def enclosed_tessellation(
 
         from libpysal import graph
 
-        graph.Graph.build_fuzzy_contiguity(tessellation, buffer=1e-8)
+        graph.Graph.build_fuzzy_contiguity(tessellation, buffer=1e-6)
 
     Returns
     -------


### PR DESCRIPTION
We have noticed a nasty issue with the contiguity of enclosed tessellation caused by floating point imprecision within GEOS. Spent some time trying to fix it but I don't think it is possible with the current version of GEOS / shapely. For our use case, there is a solution, so making a note in the docstring.

Repr of the issue:

```py
import geopandas as gpd
import momepy

streets = gpd.read_file(momepy.datasets.get_path("bubenec"), layer="streets")
buildings = gpd.read_file(momepy.datasets.get_path("bubenec"), layer="buildings")

enclosures = momepy.enclosures(streets, limit=momepy.buffered_limit(buildings, buffer=50))

tess = momepy.enclosed_tessellation(buildings, enclosures)

tess.union_all()
```
<img width="260" alt="Screenshot 2024-06-13 at 22 00 25" src="https://github.com/pysal/momepy/assets/36797143/6f3f8ced-9d76-409b-a0a1-469ce445b5a7">

The lines shown in the interior are actual gaps in contiguity when building the graph:

```py
from libpysal.graph import Graph

m = tess_new.explore()
g = Graph.build_contiguity(tess_new, rook=False, strict=True)
g.explore(tess_new, m=m)
m
```
<img width="637" alt="Screenshot 2024-06-13 at 22 02 06" src="https://github.com/pysal/momepy/assets/36797143/7184db48-52f7-4548-83e0-e81bbd534746">

It's been in the enclosed tessellation since the first implementation 4 years ago.