### PR TITLE
API: return morphological tessellation as a GeoDataFrame

### DIFF
--- a/docs/user_guide/combined/distribution.ipynb
+++ b/docs/user_guide/combined/distribution.ipynb
@@ -43,8 +43,7 @@
                 "buildings = ox.projection.project_gdf(gdf).reset_index(drop=True)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tess = momepy.morphological_tessellation(buildings, clip=limit)\n",
-                "tessellation = tess.to_frame(\"geometry\")"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {

--- a/docs/user_guide/combined/intensity.ipynb
+++ b/docs/user_guide/combined/intensity.ipynb
@@ -38,18 +38,14 @@
             "source": [
                 "point = (40.731603, -73.977857)\n",
                 "dist = 1000\n",
-                "gdf = ox.features_from_point(\n",
-                "    point, dist=dist, tags={\"building\": True}\n",
-                ")\n",
+                "gdf = ox.features_from_point(point, dist=dist, tags={\"building\": True})\n",
                 "gdf_projected = ox.projection.project_gdf(gdf)\n",
                 "buildings = gdf_projected[\n",
                 "    gdf_projected.geom_type.isin([\"Polygon\", \"MultiPolygon\"])\n",
                 "].reset_index(drop=True)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tessellation = momepy.morphological_tessellation(\n",
-                "    buildings, clip=limit\n",
-                ").to_frame('geometry')"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {
@@ -166,7 +162,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "tessellation[\"FAR\"] =  buildings[\"floor_area\"] / tessellation.area"
+                "tessellation[\"FAR\"] = buildings[\"floor_area\"] / tessellation.area"
             ]
         },
         {

--- a/docs/user_guide/getting_started.ipynb
+++ b/docs/user_guide/getting_started.ipynb
@@ -427,7 +427,6 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "tessellation = tessellation.to_frame(\"geometry\")\n",
                 "tessellation[\"CAR\"] = buildings.area / tessellation.area"
             ]
         },

--- a/docs/user_guide/simple/dimension.ipynb
+++ b/docs/user_guide/simple/dimension.ipynb
@@ -109,7 +109,6 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "tessellation = tessellation.to_frame(\"geometry\")\n",
                 "tessellation[\"axis_length\"] = momepy.longest_axis_length(tessellation)"
             ]
         },

--- a/docs/user_guide/simple/shape.ipynb
+++ b/docs/user_guide/simple/shape.ipynb
@@ -52,8 +52,7 @@
                 "buildings = ox.projection.project_gdf(gdf)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tess = momepy.morphological_tessellation(buildings, clip=limit)\n",
-                "tessellation = tess.to_frame(\"geometry\")"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {

--- a/docs/user_guide/weights/diversity.ipynb
+++ b/docs/user_guide/weights/diversity.ipynb
@@ -54,8 +54,7 @@
                 "buildings = ox.projection.project_gdf(gdf).reset_index(drop=True)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tess = momepy.morphological_tessellation(buildings, clip=limit)\n",
-                "tessellation = tess.to_frame(\"geometry\")"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {

--- a/docs/user_guide/weights/examples.ipynb
+++ b/docs/user_guide/weights/examples.ipynb
@@ -50,8 +50,7 @@
                 "buildings = ox.projection.project_gdf(gdf).reset_index(drop=True)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tess = momepy.morphological_tessellation(buildings, clip=limit)\n",
-                "tessellation = tess.to_frame(\"geometry\")"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {
@@ -512,7 +511,7 @@
                 "limit = momepy.buffered_limit(buildings)\n",
                 "tessellation = momepy.morphological_tessellation(\n",
                 "    buildings, clip=limit\n",
-                ").to_frame(\"geometry\")"
+                ")"
             ]
         },
         {

--- a/docs/user_guide/weights/two.ipynb
+++ b/docs/user_guide/weights/two.ipynb
@@ -48,8 +48,7 @@
                 "buildings = ox.projection.project_gdf(gdf).reset_index(drop=True)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tess = momepy.morphological_tessellation(buildings, clip=limit)\n",
-                "tessellation = tess.to_frame(\"geometry\")"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {

--- a/docs/user_guide/weights/weights_nb.ipynb
+++ b/docs/user_guide/weights/weights_nb.ipynb
@@ -50,8 +50,7 @@
                 "buildings = ox.projection.project_gdf(gdf).reset_index(drop=True)\n",
                 "\n",
                 "limit = momepy.buffered_limit(buildings)\n",
-                "tess = momepy.morphological_tessellation(buildings, clip=limit)\n",
-                "tessellation = tess.to_frame(\"geometry\")"
+                "tessellation = momepy.morphological_tessellation(buildings, clip=limit)"
             ]
         },
         {

--- a/momepy/functional/_elements.py
+++ b/momepy/functional/_elements.py
@@ -32,7 +32,7 @@ def morphological_tessellation(
     clip: str | shapely.Geometry | GeoSeries | GeoDataFrame | None = "bounding_box",
     shrink: float = 0.4,
     segment: float = 0.5,
-) -> GeoSeries:
+) -> GeoDataFrame:
     """Generate morphological tessellation.
 
     Morpohological tessellation is a method to divide space into cells based on
@@ -74,8 +74,8 @@ def morphological_tessellation(
 
     Returns
     -------
-    GeoSeries
-        GeoSeries with an index matching the index of input geometry
+    GeoDataFrame
+        GeoDataFrame with an index matching the index of input geometry
 
     See also
     --------
@@ -92,7 +92,7 @@ def morphological_tessellation(
         shrink=shrink,
         segment=segment,
         return_input=False,
-        as_gdf=False,
+        as_gdf=True,
     )
 
 
@@ -275,7 +275,7 @@ def _tess(ix, poly, blg, threshold, shrink, segment, enclosure_id):
     )
 
 
-def verify_tessellation(tesselation, geometry):
+def verify_tessellation(tessellation, geometry):
     """Check whether result matches buildings and contains only Polygons.
 
     Checks if the generated tessellation fully matches the input buildings, i.e. if
@@ -287,7 +287,7 @@ def verify_tessellation(tesselation, geometry):
 
     Parameters
     ----------
-    tesselation : GeoSeries | GeoDataFrame
+    tessellation : GeoSeries | GeoDataFrame
         tessellation geometry
     geometry : GeoSeries | GeoDataFrame
         building geometry used to generate tessellation
@@ -299,7 +299,7 @@ def verify_tessellation(tesselation, geometry):
     """
     # check against input layer
     ids_original = geometry.index
-    ids_generated = tesselation.index
+    ids_generated = tessellation.index
     collapsed = pd.Index([])
     if len(ids_original) != len(ids_generated):
         collapsed = ids_original.difference(ids_generated)
@@ -314,7 +314,9 @@ def verify_tessellation(tesselation, geometry):
         )
 
     # check MultiPolygons - usually caused by error in input geometry
-    multipolygons = tesselation[tesselation.geometry.geom_type == "MultiPolygon"].index
+    multipolygons = tessellation[
+        tessellation.geometry.geom_type == "MultiPolygon"
+    ].index
     if len(multipolygons) > 0:
         warnings.warn(
             message=(

--- a/momepy/functional/tests/test_elements.py
+++ b/momepy/functional/tests/test_elements.py
@@ -34,6 +34,7 @@ class TestElements:
         assert (tessellation.geom_type == "Polygon").all()
         assert tessellation.crs == self.df_buildings.crs
         assert_index_equal(tessellation.index, self.df_buildings.index)
+        assert isinstance(tessellation, gpd.GeoDataFrame)
 
         clipped = mm.morphological_tessellation(
             self.df_buildings,


### PR DESCRIPTION
Normally, you will want to use tessellation as a gdf, so easier to return it as such and avoid all those `to_frame` calls. This also makes the output type consistent with `enclosed_tessellation`.