### PR TITLE
ENH: add flow mode to COINS

### DIFF
--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -445,7 +445,7 @@ def _angle_between_two_lines(line1, line2):
     dot_product = v1[0] * v2[0] + v1[1] * v2[1]
     norm_v1 = math.sqrt(v1[0] ** 2 + v1[1] ** 2)
     norm_v2 = math.sqrt(v2[0] ** 2 + v2[1] ** 2)
-    cos_theta = dot_product / (norm_v1 * norm_v2)
+    cos_theta = round(dot_product / (norm_v1 * norm_v2), 6)  # precision issues fix
     angle = math.degrees(math.acos(cos_theta))
 
     return angle

--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -45,15 +45,16 @@ class COINS:
         Segments will only be considered part of the same stroke group
         if the interior angle between them is above the threshold.
     flow_mode : bool, default False
-        Continuity can be derived based on visiblity or flow. The former creates a
-        stroke group break at any angle above the ``angle_threshold`` no matter if it
-        is on a node where two LineStrings intersect or if it is on an internal node
-        within the LineString. This mimics the "visible continuity". The latter creates
-        a stroke group break only at the end points of LineStrings, following the "flow"
-        definition of continuty where the direction of flow can change only when there
-        is an intersection present. This also ensures that each LineString can be
-        assigned only a single stroke group. Note that this option is not covered by
-        :cite:`tripathy2020open`.
+        Continuity can be derived based on either visibility (``flow_mode=False``) or
+        flow (``flow_mode=True``). In the former case, a stroke group break is created
+        at any angle above the ``angle_threshold``, even at internal nodes within the
+        LineString (so one LineString can be divided into multiple stroke groups if its
+        segments connect at an angle above ``angle_threshold``). This corresponds to
+        visibility-based continuity. In the latter case, stroke group breaks are only
+        created at the end points of LineStrings, following the "flow" definition of
+        continuity where the direction of flow can change only at intersections. This
+        also ensures that each LineString can be assigned only a single stroke group.
+        Note that this option is not covered by :cite:`tripathy2020open`.
 
     Examples
     --------

--- a/momepy/tests/test_coins.py
+++ b/momepy/tests/test_coins.py
@@ -217,3 +217,59 @@ class TestCOINS:
         stroke_attr = coins.stroke_attribute()
         # expecting both lines to be part of same group
         assert stroke_attr[0] != stroke_attr[1]
+
+    def test_flow_mode(self):
+        roads = gpd.GeoSeries.from_wkt(
+            [
+                "LINESTRING (682705.3550242907 5614078.5083698435, 682708.0849458438 5614073.895229458, 682712.4572257706 5614067.790682519)",  # noqa: E501
+                "LINESTRING (682680.7622123861 5614067.175691795, 682695.2357549993 5614044.543851833)",  # noqa: E501
+                "LINESTRING (682705.3550242907 5614078.5083698435, 682680.7622123861 5614067.175691795)",  # noqa: E501
+                "LINESTRING (682709.3980117479 5614080.294302186, 682705.3550242907 5614078.5083698435)",  # noqa: E501
+                "LINESTRING (682677.6759713582 5614091.273667651, 682677.2937893708 5614090.719229713, 682672.358253116 5614084.113239679, 682680.7622123861 5614067.175691795)",  # noqa: E501
+            ]
+        )
+        no_flow = mm.COINS(roads, 120)
+        pm = no_flow._premerge()
+        assert pm.p1_final.tolist() == [
+            "line_break",
+            0,
+            7,
+            4,
+            "line_break",
+            "line_break",
+            5,
+            "line_break",
+        ]
+        assert pm.p2_final.tolist() == [
+            1,
+            "line_break",
+            "line_break",
+            "line_break",
+            3,
+            6,
+            "line_break",
+            2,
+        ]
+
+        flow = mm.COINS(roads, 120, flow_mode=True)
+        pm = flow._premerge()
+        assert pm.p1_final.tolist() == [
+            "line_break",
+            0,
+            7,
+            4,
+            "line_break",
+            "line_break",
+            5,
+            6,
+        ]
+        assert pm.p2_final.tolist() == [
+            1,
+            "line_break",
+            "line_break",
+            "line_break",
+            3,
+            6,
+            7,
+            2,
+        ]


### PR DESCRIPTION
This adds flow mode of continuity which ensures that there's only a one stroke group per LineString and does not cause breakage when dealing with stroke attributes rather than stroke geometries.