### PR TITLE
let COINS run even if there's overlapping geometry

### DIFF
--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -11,6 +11,7 @@ Date: May 29, 2021
 
 import collections
 import math
+import warnings
 
 import geopandas as gpd
 import numpy as np
@@ -435,11 +436,15 @@ def _angle_between_two_lines(line1, line2):
 
     # make sure lines are not identical
     if len(points) == 2:
-        raise ValueError(
-            "Lines are identical. Please revise input data "
-            "to ensure no lines are identical or overlapping. "
-            "You can check for duplicates using `gdf.geometry.duplicated()`."
+        warnings.warn(
+            f"Lines are between points {points.keys()} identical. Please revise input "
+            "data to ensure no lines are identical or overlapping. "
+            "You can check for duplicates using `gdf.geometry.duplicated()`. Assuming"
+            'an angle of 0 degrees.',
+            UserWarning,
+            stacklevel=3
         )
+        return 0
 
     # make sure lines do touch
     if len(points) == 4:

--- a/momepy/coins.py
+++ b/momepy/coins.py
@@ -440,9 +440,9 @@ def _angle_between_two_lines(line1, line2):
             f"Lines are between points {points.keys()} identical. Please revise input "
             "data to ensure no lines are identical or overlapping. "
             "You can check for duplicates using `gdf.geometry.duplicated()`. Assuming"
-            'an angle of 0 degrees.',
+            "an angle of 0 degrees.",
             UserWarning,
-            stacklevel=3
+            stacklevel=3,
         )
         return 0
 


### PR DESCRIPTION
The check for overlapping lines we have added in 0.8 is a bit annoying as in most cases, it is a single stroke group that is affected. So I am changing that to a warning and using 0 as an angle.

This also means that some minor issues caused by the simplification pipeline will not cause the whole thing to break on this error.

cc @anastassiavybornova 