### PR TITLE
ENH: retain index of buildings and plots intersecting sightlines

### DIFF
--- a/momepy/streetscape.py
+++ b/momepy/streetscape.py
@@ -1007,6 +1007,8 @@ class Streetscape:
                         np.nan,
                         np.nan,
                         np.nan,
+                        {},
+                        {},
                     ]
                 )
                 continue
@@ -1141,6 +1143,7 @@ class Streetscape:
                 ]
                 + wd_ratio_list
                 + wp_ratio_list
+                + [set(left_parcel_seq_sb_ids), set(right_parcel_seq_sb_ids)]
             )
 
         columns = [
@@ -1162,6 +1165,8 @@ class Streetscape:
             "plot_WP_ratio",
             "left_plot_WP_ratio",
             "right_plot_WP_ratio",
+            "left_plot_seq_sb_index",
+            "right_plot_seq_sb_index",
         ]
 
         self._aggregate_plot_data = pd.DataFrame(values, columns=columns).set_index(
@@ -1928,8 +1933,8 @@ class Streetscape:
                     "left_built_coverage",
                     "right_built_coverage",
                     "built_coverage",
-                    "left_seq_sb_ids",
-                    "right_seq_sb_ids",
+                    "left_seq_sb_index",
+                    "right_seq_sb_index",
                 ],
             )
             .set_index("street_index")

--- a/momepy/streetscape.py
+++ b/momepy/streetscape.py
@@ -67,7 +67,9 @@ class Streetscape:
 
     The function also provides the distribution of measures separately for the two sides
     of the street (right and left, assigned arbitrarily). Indicators for the left side
-    are preceded by ``left_*`` and for the right side by ``right_*``.
+    are preceded by ``left_*`` and for the right side by ``right_*`` At the same time,
+    you can retrieve the index of buildings that affected each street via
+    ``*_seq_sb_ids``.
 
     Additional street-level measures are: ``street_length`` (Street Length),
     ``windingness`` (Windingness or Curvature of Streets, equal to 1 -
@@ -1847,6 +1849,8 @@ class Streetscape:
                     ind_left_built_coverage,
                     ind_right_built_coverage,
                     ind_built_coverage,
+                    set(left_seq_sb_ids),
+                    set(right_seq_sb_ids),
                 ]
             )
 
@@ -1924,6 +1928,8 @@ class Streetscape:
                     "left_built_coverage",
                     "right_built_coverage",
                     "built_coverage",
+                    "left_seq_sb_ids",
+                    "right_seq_sb_ids",
                 ],
             )
             .set_index("street_index")

--- a/momepy/tests/test_streetscape.py
+++ b/momepy/tests/test_streetscape.py
@@ -28,7 +28,7 @@ class TestStreetscape:
         street_df = sc.street_level()
         point_df = sc.point_level()
 
-        assert street_df.shape == (35, 75)
+        assert street_df.shape == (35, 77)
         assert point_df.shape == (1277, 24)
 
     def test_no_dtm(self):
@@ -38,7 +38,7 @@ class TestStreetscape:
         street_df = sc.street_level()
         point_df = sc.point_level()
 
-        assert street_df.shape == (35, 92)
+        assert street_df.shape == (35, 94)
         assert point_df.shape == (1277, 30)
 
     def test_no_plots(self):
@@ -51,7 +51,7 @@ class TestStreetscape:
         street_df = sc.street_level()
         point_df = sc.point_level()
 
-        assert street_df.shape == (35, 79)
+        assert street_df.shape == (35, 81)
         assert point_df.shape == (1277, 24)
 
     def test_all_values(self):
@@ -67,11 +67,13 @@ class TestStreetscape:
         street_df = sc.street_level()
         point_df = sc.point_level()
 
-        assert street_df.shape == (35, 102)
+        assert street_df.shape == (35, 104)
         assert point_df.shape == (1277, 30)
 
         np.testing.assert_allclose(
-            street_df.drop(columns="geometry").median().to_numpy(),
+            street_df.drop(columns=["geometry", "left_seq_sb_ids", "right_seq_sb_ids"])
+            .median()
+            .to_numpy(),
             [
                 40.0,
                 1.0,
@@ -284,6 +286,8 @@ class TestStreetscape:
                 "left_built_coverage",
                 "right_built_coverage",
                 "built_coverage",
+                "left_seq_sb_ids",
+                "right_seq_sb_ids",
                 "nodes_degree_1",
                 "nodes_degree_4",
                 "nodes_degree_3_5_plus",

--- a/momepy/tests/test_streetscape.py
+++ b/momepy/tests/test_streetscape.py
@@ -29,7 +29,7 @@ class TestStreetscape:
         point_df = sc.point_level()
 
         assert street_df.shape == (35, 77)
-        assert point_df.shape == (1277, 24)
+        assert point_df.shape == (1277, 26)
 
     def test_no_dtm(self):
         sc = momepy.Streetscape(self.streets, self.buildings)
@@ -39,7 +39,7 @@ class TestStreetscape:
         point_df = sc.point_level()
 
         assert street_df.shape == (35, 96)
-        assert point_df.shape == (1277, 30)
+        assert point_df.shape == (1277, 32)
 
     def test_no_plots(self):
         rioxarray = pytest.importorskip("rioxarray")
@@ -52,7 +52,7 @@ class TestStreetscape:
         point_df = sc.point_level()
 
         assert street_df.shape == (35, 81)
-        assert point_df.shape == (1277, 24)
+        assert point_df.shape == (1277, 26)
 
     def test_all_values(self):
         rioxarray = pytest.importorskip("rioxarray")
@@ -68,7 +68,7 @@ class TestStreetscape:
         point_df = sc.point_level()
 
         assert street_df.shape == (35, 106)
-        assert point_df.shape == (1277, 30)
+        assert point_df.shape == (1277, 32)
 
         np.testing.assert_allclose(
             street_df.drop(
@@ -188,7 +188,15 @@ class TestStreetscape:
         )
 
         np.testing.assert_allclose(
-            point_df.drop(columns="geometry").median().to_numpy(),
+            point_df.drop(
+                columns=[
+                    "geometry",
+                    "left_seq_sb_index",
+                    "right_seq_sb_index",
+                ]
+            )
+            .median()
+            .to_numpy(),
             [
                 1.0,
                 50.0,
@@ -354,6 +362,8 @@ class TestStreetscape:
                 "right_bc",
                 "front_sb",
                 "back_sb",
+                "left_seq_sb_index",
+                "right_seq_sb_index",
                 "left_plot_seq_sb",
                 "left_plot_seq_sb_depth",
                 "right_plot_seq_sb",

--- a/momepy/tests/test_streetscape.py
+++ b/momepy/tests/test_streetscape.py
@@ -39,7 +39,7 @@ class TestStreetscape:
         point_df = sc.point_level()
 
         assert street_df.shape == (35, 96)
-        assert point_df.shape == (1277, 32)
+        assert point_df.shape == (1277, 34)
 
     def test_no_plots(self):
         rioxarray = pytest.importorskip("rioxarray")
@@ -68,7 +68,7 @@ class TestStreetscape:
         point_df = sc.point_level()
 
         assert street_df.shape == (35, 106)
-        assert point_df.shape == (1277, 32)
+        assert point_df.shape == (1277, 34)
 
         np.testing.assert_allclose(
             street_df.drop(
@@ -193,6 +193,8 @@ class TestStreetscape:
                     "geometry",
                     "left_seq_sb_index",
                     "right_seq_sb_index",
+                    "left_plot_seq_sb_index",
+                    "right_plot_seq_sb_index",
                 ]
             )
             .median()
@@ -368,6 +370,8 @@ class TestStreetscape:
                 "left_plot_seq_sb_depth",
                 "right_plot_seq_sb",
                 "right_plot_seq_sb_depth",
+                "left_plot_seq_sb_index",
+                "right_plot_seq_sb_index",
                 "os_count",
                 "os",
                 "sb_count",

--- a/momepy/tests/test_streetscape.py
+++ b/momepy/tests/test_streetscape.py
@@ -38,7 +38,7 @@ class TestStreetscape:
         street_df = sc.street_level()
         point_df = sc.point_level()
 
-        assert street_df.shape == (35, 94)
+        assert street_df.shape == (35, 96)
         assert point_df.shape == (1277, 30)
 
     def test_no_plots(self):
@@ -67,11 +67,19 @@ class TestStreetscape:
         street_df = sc.street_level()
         point_df = sc.point_level()
 
-        assert street_df.shape == (35, 104)
+        assert street_df.shape == (35, 106)
         assert point_df.shape == (1277, 30)
 
         np.testing.assert_allclose(
-            street_df.drop(columns=["geometry", "left_seq_sb_ids", "right_seq_sb_ids"])
+            street_df.drop(
+                columns=[
+                    "geometry",
+                    "left_seq_sb_index",
+                    "right_seq_sb_index",
+                    "left_plot_seq_sb_index",
+                    "right_plot_seq_sb_index",
+                ]
+            )
             .median()
             .to_numpy(),
             [
@@ -286,8 +294,8 @@ class TestStreetscape:
                 "left_built_coverage",
                 "right_built_coverage",
                 "built_coverage",
-                "left_seq_sb_ids",
-                "right_seq_sb_ids",
+                "left_seq_sb_index",
+                "right_seq_sb_index",
                 "nodes_degree_1",
                 "nodes_degree_4",
                 "nodes_degree_3_5_plus",
@@ -316,6 +324,8 @@ class TestStreetscape:
                 "plot_WP_ratio",
                 "left_plot_WP_ratio",
                 "right_plot_WP_ratio",
+                "left_plot_seq_sb_index",
+                "right_plot_seq_sb_index",
                 "slope_degree",
                 "slope_percent",
                 "n_slopes",


### PR DESCRIPTION
This allows linking the data back to building and plot geometry if needed. Using sets as there can be more than one hit.