### PR TITLE
DOC: fix the image link in lcustering example

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -17,3 +17,6 @@ python:
 conda:
   environment: docs/environment.yml
 formats: []
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py


### PR DESCRIPTION
I think I changed the tessellation guide which broke the link.