### PR TITLE
MAINT: add more pytest.approx calls

### DIFF
--- a/momepy/tests/test_dimension.py
+++ b/momepy/tests/test_dimension.py
@@ -215,7 +215,7 @@ class TestDimensions:
             self.df_streets, self.df_buildings, heights=height, tick_length=100
         )
         assert results2.w[0] == 70.7214870365335
-        assert results2.wd[0] == 8.50508193935929
+        assert results2.wd[0] == pytest.approx(8.50508193935929)
         assert results2.h[0] == pytest.approx(23.87158296249206)
         assert results2.p[0] == pytest.approx(0.3375435664999579)
         assert results2.o[0] == 0.5769230769230769

--- a/momepy/tests/test_intensity.py
+++ b/momepy/tests/test_intensity.py
@@ -205,7 +205,7 @@ class TestIntensity:
             nodes, edges, sw, weighted=True, node_degree="degree"
         ).series
         array = mm.NodeDensity(nodes, edges, W).series
-        assert density.mean() == 0.005534125924228438
+        assert density.mean() == pytest.approx(0.005534125924228438)
         assert weighted.mean() == pytest.approx(0.010090861332429164)
         assert array.mean() == 0.01026753724860306
 


### PR DESCRIPTION
These tests failed on Debian i386, probably due to x87 excess precision: https://bugs.debian.org/1103140