### PR TITLE
SciPy sparse array migration from sparse matrices

### DIFF
--- a/momepy/weights.py
+++ b/momepy/weights.py
@@ -155,7 +155,12 @@ def sw_high(k, gdf=None, weights=None, ids=None, contiguity="queen", silent=True
     if k > 1:
         id_order = first_order.id_order
         w = first_order.sparse
-        wk = sum(w**x for x in range(1, k + 1))
+        #### when scipy>=1.12 is assured, we can do:
+        # wk = sum(scipy.sparse.linalg.matrix_power(w, x) for x in range(1, k+1))
+        wk = w.copy()
+        for _ in range(k - 1):
+            wk = wk @ w + w
+        ####
         rk, ck = wk.nonzero()
         sk = set(zip(rk, ck, strict=True))
         sk = {(i, j) for i, j in sk if i != j}


### PR DESCRIPTION
As per the SciPy sparray migration guide this is a "pass 1" set of changes.
"Pass 1" essentially makes sure your code is compatible for both sparray and spmatrix. It doesn't actually change any sparse objects to sparray. It only changes usage of `*` and `**` and gets rid of some functions like spdiags.

In this repo, we only need to change one use of `**` for matrix power. Once scipy v1.12 is the minimal version we can use `scipy.sparse.linalg.matrix_power` for matrix power. But this PR uses `@` repeatedly instead. It is close to the same speed for large matrices.

This change should also help if/when the code gets moved from using `w` to `graph`.