### PR TITLE
Add geographic CRS warning to street_profile

### DIFF
--- a/momepy/dimension.py
+++ b/momepy/dimension.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -458,6 +459,16 @@ def street_profile(
     3  50.000000  1.000000              NaN        NaN               NaN       NaN
     4  50.000000  1.000000              NaN        NaN               NaN       NaN
     """
+
+    # Warn if using geographic CRS
+    if streets.crs is not None and streets.crs.is_geographic:
+        warnings.warn(
+            "Geometry is in a geographic CRS. Results from 'street_profile' "
+            "are likely incorrect. Use 'GeoDataFrame.to_crs()' to re-project "
+            "geometries to a projected CRS before using this function.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     # filter relevant buildings and streets
     inp, res = shapely.STRtree(streets.geometry).query(

--- a/momepy/tests/test_dimension.py
+++ b/momepy/tests/test_dimension.py
@@ -170,6 +170,19 @@ class TestDimensions:
             "hw_ratio"
         ].equals(pd.Series([np.nan, 0.35]))
 
+    def test_street_profile_geographic_crs_warning(self):
+        # Test that a warning is raised when using geographic CRS
+        streets_geo = self.df_streets.to_crs("EPSG:4326")
+        buildings_geo = self.df_buildings.to_crs("EPSG:4326")
+
+        with pytest.warns(UserWarning, match="geographic CRS"):
+            mm.street_profile(
+                streets_geo,
+                buildings_geo,
+                tick_length=50,
+                distance=1,
+            )
+
     def test_weighted_char(self):
         weighted = mm.weighted_character(
             self.df_buildings.height, self.df_buildings.area, self.graph


### PR DESCRIPTION
## Description

This PR adds a warning to the `street_profile` function when it is called with geographic coordinates (latitude/longitude), which can lead to incorrect distance calculations and results.

Fixes #369

## Changes

- Added CRS validation check in `street_profile()` function
- Issues a `UserWarning` when `streets.crs.is_geographic` is `True`
- Warning message directs users to use `GeoDataFrame.to_crs()` to reproject to a projected CRS
- Added test `test_street_profile_geographic_crs_warning()` to verify warning behavior

## Testing

- ✅ All existing tests pass (10/10 in test_dimension.py)
- ✅ New test verifies warning is raised with geographic CRS
- ✅ Code formatted with ruff and passes all linting checks

## Example

When users call `street_profile` with geographic coordinates:

```python
streets_geo = streets.to_crs("EPSG:4326")  # Geographic CRS
result = mm.street_profile(streets_geo, buildings_geo)
```

They will now see:
```
UserWarning: Geometry is in a geographic CRS. Results from 'street_profile' 
are likely incorrect. Use 'GeoDataFrame.to_crs()' to re-project geometries 
to a projected CRS before using this function.
```

## Checklist

- [x] Tests added and passing
- [x] Code formatted with ruff
- [x] Follows contribution guidelines
- [x] References issue #369