### PR TITLE
adapt `release_to_pypi.yml` for trusted publishing

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -10,6 +10,9 @@ jobs:
   build-n-publish:
     name: Build and publish momepy to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # MANDATORY for trusted publishing to PyPI
+      contents: write  # MANDATORY for the Github release action
 
     steps:
       - uses: actions/checkout@v6
@@ -41,6 +44,3 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
adapt [`release_to_pypi.yml`](https://github.com/pysal/momepy/blob/cd32403107c615e9ae898308656f94c949869f2a/.github/workflows/release_to_pypi.yml) for trusted publishing