### PR TITLE
CI: remove iprogress

### DIFF
--- a/ci/envs/314-latest.yaml
+++ b/ci/envs/314-latest.yaml
@@ -29,7 +29,6 @@ dependencies:
   - geopy
   - inequality
   - ipywidgets
-  - Iprogress
   - ipykernel
   - jupyter
   - matplotlib


### PR DESCRIPTION
Trying to figure out what was this needed for. It was last updated in 2016 and is causing trouble in env resolution.