### PR TITLE
BUG: raise informative error for MultiPolygon in corner-based shape metrics (#739)

### DIFF
--- a/momepy/shape.py
+++ b/momepy/shape.py
@@ -455,6 +455,24 @@ def shape_index(
     return np.sqrt(geometry.area / np.pi) / (0.5 * longest_axis_length)
 
 
+def _check_no_multipolygons(geometry: GeoDataFrame | GeoSeries, func_name: str) -> None:
+    """Ensure no MultiPolygons are present when relying on polygon exteriors.
+
+    Corner-based metrics use ``GeoSeries.exterior``, which is undefined for
+    MultiPolygons. Without this check the metrics either fail with a cryptic
+    length-mismatch error or silently return ``NaN``. Raising here gives users an
+    actionable message instead.
+    """
+    if (geometry.geom_type == "MultiPolygon").any():
+        raise ValueError(
+            f"momepy.{func_name} does not support MultiPolygon geometries when "
+            "include_interiors=False, as it relies on polygon exteriors. Explode "
+            "MultiPolygons into single-part Polygons first (e.g. "
+            "``geometry.explode(ignore_index=True)``) or pass "
+            "include_interiors=True."
+        )
+
+
 def corners(
     geometry: GeoDataFrame | GeoSeries,
     eps: float = 10,
@@ -508,6 +526,7 @@ def corners(
     if include_interiors:
         coords = geometry.reset_index(drop=True).get_coordinates(index_parts=False)
     else:
+        _check_no_multipolygons(geometry, "corners")
         coords = geometry.reset_index(drop=True).exterior.get_coordinates(
             index_parts=False
         )
@@ -571,6 +590,7 @@ def squareness(
     if include_interiors:
         coords = geometry.reset_index(drop=True).get_coordinates(index_parts=False)
     else:
+        _check_no_multipolygons(geometry, "squareness")
         coords = geometry.reset_index(drop=True).exterior.get_coordinates(
             index_parts=False
         )
@@ -729,6 +749,7 @@ def centroid_corner_distance(
     if include_interiors:
         coords = geometry.get_coordinates(index_parts=False)
     else:
+        _check_no_multipolygons(geometry, "centroid_corner_distance")
         coords = geometry.exterior.get_coordinates(index_parts=False)
     coords[["cent_x", "cent_y"]] = geometry.centroid.get_coordinates(index_parts=False)
     ccd = coords.groupby(level=0).apply(_ccd, eps=eps)

--- a/momepy/tests/test_shape.py
+++ b/momepy/tests/test_shape.py
@@ -1,6 +1,8 @@
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pytest
+import shapely
 from libpysal.graph import Graph
 from pandas.testing import assert_frame_equal, assert_series_equal
 
@@ -271,6 +273,32 @@ class TestShape:
         )
         r = mm.centroid_corner_distance(self.df_buildings, include_interiors=True)
         assert_frame_equal(r.describe(), expected)
+
+    @pytest.mark.parametrize(
+        "func", ["corners", "squareness", "centroid_corner_distance"]
+    )
+    def test_corner_metrics_multipolygon(self, func):
+        # corner-based metrics rely on polygon exteriors, which are undefined for
+        # MultiPolygons. With include_interiors=False this used to raise a cryptic
+        # length-mismatch error (corners, squareness) or silently return NaN
+        # (centroid_corner_distance). See GH#739.
+        polygons = self.df_buildings.geometry.iloc[:3]
+        multi = gpd.GeoSeries(
+            [shapely.MultiPolygon([poly]) for poly in polygons],
+            crs=self.df_buildings.crs,
+        )
+
+        with pytest.raises(
+            ValueError, match="does not support MultiPolygon geometries"
+        ):
+            getattr(mm, func)(multi)
+
+        # include_interiors=True handles MultiPolygons and must keep working
+        getattr(mm, func)(multi, include_interiors=True)
+
+        # exploding into single-part Polygons is the documented workaround
+        exploded = multi.explode(ignore_index=True)
+        getattr(mm, func)(exploded)
 
     def test_linearity(self):
         expected = {


### PR DESCRIPTION
Fixes #739.

### Problem

`corners`, `squareness` and `centroid_corner_distance` crash or silently misbehave on MultiPolygon input. With `include_interiors=False` they use `GeoSeries.exterior`, which is undefined (`None`) for MultiPolygons. `get_coordinates()` then drops those rows, so the grouped result is shorter than the input index:

- `corners` / `squareness` → `ValueError: Length mismatch` (cryptic)
- `centroid_corner_distance` → silently returns all-`NaN` (with `RuntimeWarning: Mean of empty slice`)

### Fix

Per the discussion on #739, this takes the informative-error path rather than the design-gated full-MultiPolygon-support path. A shared `_check_no_multipolygons` guard raises an actionable `ValueError` (pointing to `geometry.explode(ignore_index=True)` or `include_interiors=True`) in the three affected functions. This turns a cryptic crash / silent-NaN into a clear message. Happy to extend to full MultiPolygon support instead if that's preferred.

### Tests

Added a parametrized `test_corner_metrics_multipolygon` over the three metrics: asserts the informative `ValueError`, that `include_interiors=True` still works, and that the `.explode()` workaround works. Without the fix all three fail (two with the length-mismatch, one with the silent NaN); with it `test_shape.py` passes (20).

Disclosure: I used AI assistance (Claude) to help locate and draft this fix, under my direction and review.
